### PR TITLE
v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-js",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AuthKit SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -21,6 +21,7 @@ interface RedirectOptions {
   type: "sign-in" | "sign-up";
   state?: any;
   invitationToken?: string;
+  passwordResetToken?: string;
 }
 
 type State = "INITIAL" | "AUTHENTICATING" | "AUTHENTICATED" | "ERROR";
@@ -86,7 +87,12 @@ export async function createClient(
     return _redirect({ ...opts, type: "sign-up" });
   }
 
-  async function _redirect({ type, state, invitationToken }: RedirectOptions) {
+  async function _redirect({
+    type,
+    state,
+    invitationToken,
+    passwordResetToken,
+  }: RedirectOptions) {
     const { codeVerifier, codeChallenge } = await createPkceChallenge();
     // store the code verifier in session storage for later use (after the redirect back from authkit)
     window.sessionStorage.setItem(storageKeys.codeVerifier, codeVerifier);
@@ -97,6 +103,7 @@ export async function createClient(
       codeChallenge,
       codeChallengeMethod: "S256",
       invitationToken,
+      passwordResetToken,
       state: state ? JSON.stringify(state) : undefined,
     });
 

--- a/src/interfaces/get-authorization-url-options.interface.ts
+++ b/src/interfaces/get-authorization-url-options.interface.ts
@@ -9,6 +9,7 @@ export interface GetAuthorizationUrlOptions {
   state?: string;
   screenHint?: "sign-up" | "sign-in";
   invitationToken?: string;
+  passwordResetToken?: string;
   codeChallenge?: string;
   codeChallengeMethod?: string;
 }

--- a/src/utils/get-authorization-url.ts
+++ b/src/utils/get-authorization-url.ts
@@ -13,6 +13,7 @@ export function getAuthorizationUrl(
     redirectUri,
     state,
     screenHint,
+    passwordResetToken,
     invitationToken,
     codeChallenge,
     codeChallengeMethod,
@@ -42,6 +43,7 @@ export function getAuthorizationUrl(
     state,
     screen_hint: screenHint,
     invitation_token: invitationToken,
+    password_reset_token: passwordResetToken,
     code_challenge: codeChallenge,
     code_challenge_method: codeChallengeMethod,
   });


### PR DESCRIPTION
Adds support for `password_reset_token` in `signIn()`


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"support-password-reset-token-in-sign-in","parentHead":"027e6b57de8ecb2eaf9102394c2bc02103e07381","parentPull":10,"trunk":"main"}
```
-->
