### PR TITLE
call `onRefresh` after code is exchanged

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -187,6 +187,7 @@ export async function createClient(
           if (authenticationResponse) {
             _authkitClientState = "AUTHENTICATED";
             setSessionData(authenticationResponse, { devMode });
+            _onRefresh && _onRefresh(authenticationResponse);
             onRedirectCallback({ state, ...authenticationResponse });
           }
         } catch (error) {


### PR DESCRIPTION
The name `onRefresh` is suddenly less accurate, but you definitely want this logic to run on all authentication responses.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
