### PR TITLE
v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-js",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AuthKit SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -186,6 +186,7 @@ export async function createClient(
 
           if (authenticationResponse) {
             _authkitClientState = "AUTHENTICATED";
+            _scheduleAutomaticRefresh();
             setSessionData(authenticationResponse, { devMode });
             _onRefresh && _onRefresh(authenticationResponse);
             onRedirectCallback({ state, ...authenticationResponse });


### PR DESCRIPTION
fixes:
- call `onRefresh` on reswonse from code exchange
- schedule refreshes after code exchange

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"schedule-refreshes-after-code-exchange","parentHead":"1940877bd23416cb38813eec8cd4c7607ec20074","parentPull":13,"trunk":"main"}
```
-->
