### PR TITLE
fix refresh timing

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -74,9 +74,10 @@ export async function createClient(
         return true;
       }
 
-      // TODO: is this configurable?
+      // TODO: should LEEWAY be configurable?
       const LEEWAY = 10 * 1000; // 10 seconds
-      return expiresAt < Date.now() - LEEWAY;
+      const refreshTime = expiresAt - LEEWAY;
+      return refreshTime < Date.now();
     }
     return false;
   };


### PR DESCRIPTION
We intend to refresh _before_ tokens expire, but previously this code was very unfortunately refreshing shortly after tokens expire.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
