### PR TITLE
always throw when `getAccessToken` fails

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -128,7 +128,11 @@ export async function createClient(
       try {
         await refreshSession();
       } catch (err) {
-        throw new LoginRequiredError();
+        if (err instanceof RefreshError) {
+          throw new LoginRequiredError();
+        } else {
+          throw err;
+        }
       }
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,5 @@
+export class AuthKitError extends Error {}
+export class RefreshError extends AuthKitError {}
+export class LoginRequiredError extends AuthKitError {
+  readonly message: string = "No access token available";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { createClient } from "./create-client";
 export { getClaims } from "./utils/session-data";
 export { User, AuthenticationResponse } from "./interfaces";
+export { AuthKitError, LoginRequiredError } from "./errors";

--- a/src/utils/authenticate-with-refresh-token.ts
+++ b/src/utils/authenticate-with-refresh-token.ts
@@ -1,3 +1,4 @@
+import { RefreshError } from "../errors";
 import { AuthenticationResponseRaw } from "../interfaces";
 import { deserializeAuthenticationResponse } from "../serializers";
 
@@ -8,8 +9,6 @@ interface AuthenticateWithRefreshTokenOptions {
   organizationId?: string;
   useCookie: boolean;
 }
-
-export class RefreshError extends Error {}
 
 export async function authenticateWithRefreshToken({
   baseUrl,


### PR DESCRIPTION
(Previously this could return undefined).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
