### PR TITLE
add `onRefreshError`

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -51,6 +51,7 @@ export async function createClient(
     },
     onRedirectCallback = (_: RedirectParams) => {},
     onRefresh: _onRefresh,
+    onRefreshFailure: _onRefreshFailure,
   } = options;
 
   const _clientId = clientId;
@@ -168,7 +169,6 @@ export async function createClient(
     if (isRedirectCallback(redirectUri, searchParams)) {
       await _handleCallback();
     } else {
-      // TODO: if  this succeeds kick off the auto refresh timer?
       try {
         await refreshSession();
         _scheduleAutomaticRefresh();
@@ -279,8 +279,8 @@ export async function createClient(
     } catch (error: unknown) {
       console.error(error);
       if (error instanceof RefreshError) {
-        // TODO: fire a session ended callback?
         removeSessionData({ devMode });
+        _onRefreshFailure && _onRefreshFailure({ signIn: signIn });
       }
       // TODO: if a lock couldn't be acquired... that's not a fatal error.
       // maybe that's another state?

--- a/src/interfaces/create-client-options.interface.ts
+++ b/src/interfaces/create-client-options.interface.ts
@@ -1,4 +1,5 @@
 import { AuthenticationResponse } from "./authentication-response.interface";
+import { createClient } from "../create-client";
 
 export interface CreateClientOptions {
   apiHostname?: string;
@@ -9,6 +10,9 @@ export interface CreateClientOptions {
   onRedirectCallback?: (_: RedirectParams) => void;
   onBeforeAutoRefresh?: () => boolean;
   onRefresh?: (_: AuthenticationResponse) => void;
+  onRefreshFailure?: (args: {
+    signIn: Awaited<ReturnType<typeof createClient>>["signIn"];
+  }) => void;
 }
 
 export interface RedirectParams extends AuthenticationResponse {


### PR DESCRIPTION
This callback fires when a session refresh failed (sessions ended, session was revoked, user was deleted, etc.)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
