### PR TITLE
don't trigger onRefreshFailure on initial refresh

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -241,6 +241,8 @@ export async function createClient(
       return;
     }
 
+    const beginningState = _authkitClientState;
+
     const lock = new Lock();
     try {
       _authkitClientState = "AUTHENTICATING";
@@ -280,7 +282,12 @@ export async function createClient(
       console.error(error);
       if (error instanceof RefreshError) {
         removeSessionData({ devMode });
-        _onRefreshFailure && _onRefreshFailure({ signIn: signIn });
+        // fire the refresh failure UNLESS this is the initial refresh attempt
+        // (the initial refresh is expected to fail if a user has not logged in
+        // ever or recently)
+        beginningState !== "INITIAL" &&
+          _onRefreshFailure &&
+          _onRefreshFailure({ signIn: signIn });
       }
       // TODO: if a lock couldn't be acquired... that's not a fatal error.
       // maybe that's another state?


### PR DESCRIPTION
authkit-js attempts to refresh the session when the page loads (unless a code is present). This initial request should NOT trigger the `onRefreshFailure` logic.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
