### PR TITLE
don't proactively refresh on hidden tabs

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -47,7 +47,7 @@ export async function createClient(
       location.hostname === "127.0.0.1",
     // refresh if this is true
     onBeforeAutoRefresh = () => {
-      return true;
+      return !document.hidden;
     },
     onRedirectCallback = (_: RedirectParams) => {},
     onRefresh: _onRefresh,
@@ -125,7 +125,6 @@ export async function createClient(
   }
 
   async function getAccessToken(): Promise<string> {
-    // TODO: should this respect onBeforeAutoRefresh ?
     if (_needsRefresh()) {
       try {
         await refreshSession();


### PR DESCRIPTION
`getAccessToken` will still refresh when necessary, but there's no reason to eagerly fetch refresh tokens when `document.hidden`. (This also avoids making unnecessary requests and lowers the risk of being unable to acquire the tab lock).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
