### PR TITLE
v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-js",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AuthKit SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
v0.4.0

Changes:
* Only refreshes active tabs
* Doesn't call `onRefreshFailure` on the initial refresh request

Fixes:
* authkit-js would previously return stale tokens after a browser lock error

Removes:
* `refreshSession` (`getAccessToken` will refresh when necessary)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
