### PR TITLE
stop console.error initial refresh

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -172,8 +172,9 @@ export async function createClient(
       try {
         await refreshSession();
         _scheduleAutomaticRefresh();
-      } catch (error) {
-        console.log("error refreshing...", error);
+      } catch {
+        // this is expected to fail if a user doesn't
+        // have a session. do nothing.
       }
     }
   }


### PR DESCRIPTION
This is not useful information since the initial refresh is expected to fail for any first time visitors, expired sessions, etc.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
