### PR TITLE
make `refreshSession` private

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -235,13 +235,6 @@ export async function createClient(
   async function refreshSession({
     organizationId,
   }: { organizationId?: string } = {}) {
-    if (
-      _authkitClientState !== "AUTHENTICATED" &&
-      _authkitClientState !== "INITIAL"
-    ) {
-      return;
-    }
-
     const beginningState = _authkitClientState;
 
     const lock = new Lock();
@@ -319,7 +312,6 @@ export async function createClient(
     signUp,
     getUser,
     getAccessToken,
-    refreshSession,
     signOut,
   };
 }


### PR DESCRIPTION
`refreshSession` shouldn't be called directly. Developers should call `getAccessToken` which refreshes the session as needed.

Removed the authkitClientState checks from `refreshSession` (this avoids issues like `getAccessToken` not refreshing when a concurrent refresh has already started. (More improvements to come for avoiding needless refreshes).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
