### PR TITLE
support the new `context` parameter in signIn/signUp

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -22,6 +22,7 @@ interface RedirectOptions {
   state?: any;
   invitationToken?: string;
   passwordResetToken?: string;
+  context?: string;
 }
 
 type State = "INITIAL" | "AUTHENTICATING" | "AUTHENTICATED" | "ERROR";
@@ -99,6 +100,7 @@ export async function createClient(
   async function _redirect({
     type,
     state,
+    context,
     invitationToken,
     passwordResetToken,
   }: RedirectOptions) {
@@ -109,6 +111,7 @@ export async function createClient(
       clientId: _clientId,
       redirectUri: _redirectUri,
       screenHint: type,
+      context,
       codeChallenge,
       codeChallengeMethod: "S256",
       invitationToken,

--- a/src/interfaces/get-authorization-url-options.interface.ts
+++ b/src/interfaces/get-authorization-url-options.interface.ts
@@ -1,6 +1,7 @@
 export interface GetAuthorizationUrlOptions {
   clientId: string;
   connectionId?: string;
+  context?: string;
   organizationId?: string;
   domainHint?: string;
   loginHint?: string;

--- a/src/utils/get-authorization-url.ts
+++ b/src/utils/get-authorization-url.ts
@@ -6,6 +6,7 @@ export function getAuthorizationUrl(
   {
     clientId,
     connectionId,
+    context,
     domainHint,
     loginHint,
     organizationId,
@@ -33,6 +34,7 @@ export function getAuthorizationUrl(
 
   const query = toQueryString({
     connection_id: connectionId,
+    context,
     organization_id: organizationId,
     domain_hint: domainHint,
     login_hint: loginHint,


### PR DESCRIPTION
When implementing the "Initiate Login" endpoint, the `context` search param should be passed to `signIn`.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
