### PR TITLE
Add option to configure refresh buffer interval

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -83,8 +83,8 @@ export async function createClient(
           return true;
         }
 
-        const tokenRefresBufferInSeconds = refreshBufferInterval * 1000;
-        const refreshTime = expiresAt - tokenRefresBufferInSeconds;
+        const tokenRefreshBufferInSeconds = refreshBufferInterval * 1000;
+        const refreshTime = expiresAt - tokenRefreshBufferInSeconds;
         return refreshTime < Date.now();
     }
   };

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -53,6 +53,7 @@ export async function createClient(
     onRedirectCallback = (_: RedirectParams) => {},
     onRefresh: _onRefresh,
     onRefreshFailure: _onRefreshFailure,
+    refreshBufferInterval = 10,
   } = options;
 
   const _clientId = clientId;
@@ -82,9 +83,8 @@ export async function createClient(
           return true;
         }
 
-        // TODO: should LEEWAY be configurable?
-        const LEEWAY = 10 * 1000; // 10 seconds
-        const refreshTime = expiresAt - LEEWAY;
+        const tokenRefresBufferInSeconds = refreshBufferInterval * 1000;
+        const refreshTime = expiresAt - tokenRefresBufferInSeconds;
         return refreshTime < Date.now();
     }
   };

--- a/src/interfaces/create-client-options.interface.ts
+++ b/src/interfaces/create-client-options.interface.ts
@@ -2,6 +2,11 @@ import { AuthenticationResponse } from "./authentication-response.interface";
 import { createClient } from "../create-client";
 
 export interface CreateClientOptions {
+  /**
+   * How many seconds before the access token expiration to attempt a refresh.
+   */
+  refreshBufferInterval?: number;
+
   apiHostname?: string;
   https?: boolean;
   port?: number;


### PR DESCRIPTION
Adds a new `refreshBufferInterval` representing how long before the current access token expires to start attempting to refresh. For apps that may run in poor network conditions, this gives their clients more of a buffer.