### PR TITLE
Use native Web Locks API when available

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -12,3 +12,14 @@ Object.assign(globalThis, {
 Object.assign(globalThis.crypto, {
   subtle,
 });
+
+// jest@29 uses jsdom@20 which includes its own implementation of `AbortSignal`
+// that does not implement `timeout`. This workaround can be removed when jest@30
+// is released as it depends on jsdom@22 which _does_ implement `timeout`.
+AbortSignal.timeout = (ms: number) => {
+  const controller = new AbortController();
+
+  setTimeout(() => controller.abort("Timeout reached."), ms);
+
+  return controller.signal;
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dist",
     "src",
     "!src/**/*.test.ts",
+    "!src/testing/**/*",
     "LICENSE",
     "README.md"
   ],

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -31,6 +31,8 @@ const DEFAULT_HOSTNAME = "api.workos.com";
 
 const ORGANIZATION_ID_SESSION_STORAGE_KEY = "workos_organization_id";
 
+const REFRESH_LOCK_NAME = "WORKOS_REFRESH_SESSION";
+
 export async function createClient(
   clientId: string,
   options: CreateClientOptions = {},
@@ -243,8 +245,6 @@ An authorization_code was supplied for a login which did not originate at the ap
     window.history.replaceState({}, "", cleanUrl);
   }
 
-  const REFRESH_LOCK = "WORKOS_REFRESH_SESSION";
-
   async function refreshSession({
     organizationId,
   }: { organizationId?: string } = {}) {
@@ -252,7 +252,7 @@ An authorization_code was supplied for a login which did not originate at the ap
     _authkitClientState = "AUTHENTICATING";
 
     try {
-      await withLock(REFRESH_LOCK, async () => {
+      await withLock(REFRESH_LOCK_NAME, async () => {
         if (organizationId) {
           sessionStorage.setItem(
             ORGANIZATION_ID_SESSION_STORAGE_KEY,

--- a/src/testing/mock-web-locks.ts
+++ b/src/testing/mock-web-locks.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert";
+import Lock from "../vendor/browser-tabs-lock";
+
+/**
+ * Neither Node or JSDOM provide an implementation of the Web Locks API, so we
+ * implement a mock in terms of a locking implementation we do have on hand.
+ */
+export class MockWebLocks implements LockManager {
+  async request(
+    name: string,
+    optionsOrCallback: LockOptions | LockGrantedCallback,
+    callback?: LockGrantedCallback,
+  ) {
+    if (typeof optionsOrCallback === "function") {
+      callback = optionsOrCallback;
+    }
+
+    assert.ok(callback, "A callback is required.");
+
+    if (typeof optionsOrCallback !== "function" && optionsOrCallback.signal) {
+      const { signal } = optionsOrCallback;
+
+      const aborted = new Promise((_, reject) => {
+        signal.addEventListener("abort", () => {
+          reject(new DOMException("Abort error.", "AbortError"));
+        });
+      });
+
+      return Promise.race([aborted, this.perform(name, callback)]);
+    }
+
+    return this.perform(name, callback);
+  }
+
+  private async perform(
+    name: string,
+    callback: LockGrantedCallback,
+  ): Promise<void> {
+    const lock = new Lock();
+
+    try {
+      if (await lock.acquireLock(name)) {
+        return await callback({
+          name,
+          mode: "exclusive",
+        });
+      } else {
+        throw new DOMException("Abort error.", "AbortError");
+      }
+    } finally {
+      lock.releaseLock(name);
+    }
+  }
+
+  async query(): Promise<LockManagerSnapshot> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/testing/mock-web-locks.ts
+++ b/src/testing/mock-web-locks.ts
@@ -48,7 +48,7 @@ export class MockWebLocks implements LockManager {
         throw new DOMException("Abort error.", "AbortError");
       }
     } finally {
-      lock.releaseLock(name);
+      await lock.releaseLock(name);
     }
   }
 

--- a/src/utils/locking.test.ts
+++ b/src/utils/locking.test.ts
@@ -39,17 +39,17 @@ describe("locking", () => {
         describe("when the lock is held by another process", () => {
           describe("when the lock is released before the timeout", () => {
             it("returns the result of the callback", async () => {
-              const lockedTask = withLock("LOCK_NAME", () => delay(2000));
+              const lockedTask = withLock("LOCK_NAME", () => delay(500));
 
               // Ensure the locked task gets started first.
-              await Promise.race([lockedTask, delay(500)]);
+              await Promise.race([lockedTask, delay(100)]);
 
               const requestingTask = withLock("LOCK_NAME", () => true);
 
               // Check that the requesting task is indeed waiting and not resolved yet.
               await expect(
                 Promise.race([
-                  delay(500).then(() => "delayFinishedFirst"),
+                  delay(200).then(() => "delayFinishedFirst"),
                   lockedTask.then(() => "lockedProcessFinishedFirst"),
                   requestingTask.then(() => "requestingProcessFinishedFirst"),
                 ]),
@@ -62,19 +62,19 @@ describe("locking", () => {
 
           describe("when the lock is not released before the timeout", () => {
             it("throws a `LockError`", async () => {
-              const lockedTask = withLock("LOCK_NAME", () => delay(2000));
+              const lockedTask = withLock("LOCK_NAME", () => delay(500));
 
               // Ensure the locked task gets started first.
-              await Promise.race([lockedTask, delay(500)]);
+              await Promise.race([lockedTask, delay(100)]);
 
               const requestingTask = withLock("LOCK_NAME", () => true, {
-                timeout: 1000,
+                timeout: 300,
               });
 
               // Check that the requesting task is indeed waiting and not resolved yet.
               await expect(
                 Promise.race([
-                  delay(500).then(() => "delayFinishedFirst"),
+                  delay(200).then(() => "delayFinishedFirst"),
                   lockedTask.then(() => "lockedProcessFinishedFirst"),
                   requestingTask.then(() => "requestingProcessFinishedFirst"),
                 ]),

--- a/src/utils/locking.test.ts
+++ b/src/utils/locking.test.ts
@@ -1,0 +1,85 @@
+import { withLock } from "./locking";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("locking", () => {
+  describe("withLock", () => {
+    describe("when no lockName is provided", () => {
+      it("throws a TypeError", async () => {
+        expect(() => withLock("", () => {})).toThrow(TypeError);
+      });
+    });
+
+    describe("when `navigator.locks` is not available", () => {
+      it("returns the result of the callback", async () => {
+        await expect(withLock("LOCK_NAME", () => true)).resolves.toBe(true);
+      });
+
+      describe("when the lock is held by another process", () => {
+        describe("when the lock is released before the timeout", () => {
+          it("returns the result of the callback", async () => {
+            const lockedTask = withLock("LOCK_NAME", () => delay(2000));
+
+            // Ensure the locked task gets started first.
+            await Promise.race([lockedTask, delay(500)]);
+
+            const requestingTask = withLock("LOCK_NAME", () => true);
+
+            // Check that the requesting task is indeed waiting and not resolved yet.
+            await expect(
+              Promise.race([
+                delay(500).then(() => "delayFinishedFirst"),
+                lockedTask.then(() => "lockedProcessFinishedFirst"),
+                requestingTask.then(() => "requestingProcessFinishedFirst"),
+              ]),
+            ).resolves.toBe("delayFinishedFirst");
+
+            // Check that the requesting task eventually gets through.
+            await expect(requestingTask).resolves.toBe(true);
+          });
+        });
+
+        describe("when the lock is not released before the timeout", () => {
+          it("throws a `LockError`", async () => {
+            const lockedTask = withLock("LOCK_NAME", () => delay(2000));
+
+            // Ensure the locked task gets started first.
+            await Promise.race([lockedTask, delay(500)]);
+
+            const requestingTask = withLock("LOCK_NAME", () => true, {
+              timeout: 1000,
+            });
+
+            // Check that the requesting task is indeed waiting and not resolved yet.
+            await expect(
+              Promise.race([
+                delay(500).then(() => "delayFinishedFirst"),
+                lockedTask.then(() => "lockedProcessFinishedFirst"),
+                requestingTask.then(() => "requestingProcessFinishedFirst"),
+              ]),
+            ).resolves.toBe("delayFinishedFirst");
+
+            // Check that the requesting task eventually fails with the `LockError`.
+            await expect(requestingTask).rejects.toMatchObject({
+              name: "AcquisitionTimeoutError",
+              lockName: "LOCK_NAME",
+            });
+          });
+        });
+
+        describe("when the task throws an error", () => {
+          it("releases the lock and rethrows the error", async () => {
+            await expect(
+              withLock("LOCK_NAME", async () => {
+                throw new Error("Some error");
+              }),
+            ).rejects.toThrow("Some error");
+
+            // Ensure the lock is released.
+            await expect(withLock("LOCK_NAME", () => true)).resolves.toBe(true);
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/utils/locking.test.ts
+++ b/src/utils/locking.test.ts
@@ -1,3 +1,4 @@
+import { MockWebLocks } from "../testing/mock-web-locks";
 import { withLock } from "./locking";
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -10,76 +11,99 @@ describe("locking", () => {
       });
     });
 
-    describe("when `navigator.locks` is not available", () => {
-      it("returns the result of the callback", async () => {
-        await expect(withLock("LOCK_NAME", () => true)).resolves.toBe(true);
-      });
-
-      describe("when the lock is held by another process", () => {
-        describe("when the lock is released before the timeout", () => {
-          it("returns the result of the callback", async () => {
-            const lockedTask = withLock("LOCK_NAME", () => delay(2000));
-
-            // Ensure the locked task gets started first.
-            await Promise.race([lockedTask, delay(500)]);
-
-            const requestingTask = withLock("LOCK_NAME", () => true);
-
-            // Check that the requesting task is indeed waiting and not resolved yet.
-            await expect(
-              Promise.race([
-                delay(500).then(() => "delayFinishedFirst"),
-                lockedTask.then(() => "lockedProcessFinishedFirst"),
-                requestingTask.then(() => "requestingProcessFinishedFirst"),
-              ]),
-            ).resolves.toBe("delayFinishedFirst");
-
-            // Check that the requesting task eventually gets through.
-            await expect(requestingTask).resolves.toBe(true);
-          });
+    describe.each(["native", "vendor"] as const)(
+      "using the %s implementation",
+      (impelementation) => {
+        beforeEach(() => {
+          if (impelementation === "native") {
+            Object.defineProperty(navigator, "locks", {
+              value: new MockWebLocks(),
+              configurable: true,
+            });
+          }
         });
 
-        describe("when the lock is not released before the timeout", () => {
-          it("throws a `LockError`", async () => {
-            const lockedTask = withLock("LOCK_NAME", () => delay(2000));
+        afterEach(() => {
+          if (impelementation === "native") {
+            // This properties is readonly, but it's still technically a mock from
+            // JSDOM, so we can just delete it.
+            // @ts-ignore
+            delete navigator.locks;
+          }
+        });
 
-            // Ensure the locked task gets started first.
-            await Promise.race([lockedTask, delay(500)]);
+        it("returns the result of the callback", async () => {
+          await expect(withLock("LOCK_NAME", () => true)).resolves.toBe(true);
+        });
 
-            const requestingTask = withLock("LOCK_NAME", () => true, {
-              timeout: 1000,
-            });
+        describe("when the lock is held by another process", () => {
+          describe("when the lock is released before the timeout", () => {
+            it("returns the result of the callback", async () => {
+              const lockedTask = withLock("LOCK_NAME", () => delay(2000));
 
-            // Check that the requesting task is indeed waiting and not resolved yet.
-            await expect(
-              Promise.race([
-                delay(500).then(() => "delayFinishedFirst"),
-                lockedTask.then(() => "lockedProcessFinishedFirst"),
-                requestingTask.then(() => "requestingProcessFinishedFirst"),
-              ]),
-            ).resolves.toBe("delayFinishedFirst");
+              // Ensure the locked task gets started first.
+              await Promise.race([lockedTask, delay(500)]);
 
-            // Check that the requesting task eventually fails with the `LockError`.
-            await expect(requestingTask).rejects.toMatchObject({
-              name: "AcquisitionTimeoutError",
-              lockName: "LOCK_NAME",
+              const requestingTask = withLock("LOCK_NAME", () => true);
+
+              // Check that the requesting task is indeed waiting and not resolved yet.
+              await expect(
+                Promise.race([
+                  delay(500).then(() => "delayFinishedFirst"),
+                  lockedTask.then(() => "lockedProcessFinishedFirst"),
+                  requestingTask.then(() => "requestingProcessFinishedFirst"),
+                ]),
+              ).resolves.toBe("delayFinishedFirst");
+
+              // Check that the requesting task eventually gets through.
+              await expect(requestingTask).resolves.toBe(true);
             });
           });
-        });
 
-        describe("when the task throws an error", () => {
-          it("releases the lock and rethrows the error", async () => {
-            await expect(
-              withLock("LOCK_NAME", async () => {
-                throw new Error("Some error");
-              }),
-            ).rejects.toThrow("Some error");
+          describe("when the lock is not released before the timeout", () => {
+            it("throws a `LockError`", async () => {
+              const lockedTask = withLock("LOCK_NAME", () => delay(2000));
 
-            // Ensure the lock is released.
-            await expect(withLock("LOCK_NAME", () => true)).resolves.toBe(true);
+              // Ensure the locked task gets started first.
+              await Promise.race([lockedTask, delay(500)]);
+
+              const requestingTask = withLock("LOCK_NAME", () => true, {
+                timeout: 1000,
+              });
+
+              // Check that the requesting task is indeed waiting and not resolved yet.
+              await expect(
+                Promise.race([
+                  delay(500).then(() => "delayFinishedFirst"),
+                  lockedTask.then(() => "lockedProcessFinishedFirst"),
+                  requestingTask.then(() => "requestingProcessFinishedFirst"),
+                ]),
+              ).resolves.toBe("delayFinishedFirst");
+
+              // Check that the requesting task eventually fails with the `LockError`.
+              await expect(requestingTask).rejects.toMatchObject({
+                name: "AcquisitionTimeoutError",
+                lockName: "LOCK_NAME",
+              });
+            });
+          });
+
+          describe("when the task throws an error", () => {
+            it("releases the lock and rethrows the error", async () => {
+              await expect(
+                withLock("LOCK_NAME", async () => {
+                  throw new Error("Some error");
+                }),
+              ).rejects.toThrow("Some error");
+
+              // Ensure the lock is released.
+              await expect(withLock("LOCK_NAME", () => true)).resolves.toBe(
+                true,
+              );
+            });
           });
         });
-      });
-    });
+      },
+    );
   });
 });

--- a/src/utils/locking.ts
+++ b/src/utils/locking.ts
@@ -60,7 +60,7 @@ async function withVendorLock<T>(
   }
 }
 
-class LockError extends Error {
+export class LockError extends Error {
   constructor(
     override readonly name: "AcquisitionTimeoutError",
     readonly lockName: string,

--- a/src/utils/locking.ts
+++ b/src/utils/locking.ts
@@ -1,0 +1,78 @@
+import Lock from "../vendor/browser-tabs-lock";
+
+const DEFAULT_LOCK_TIMEOUT_MS = 10_000;
+
+export function withLock<T>(
+  lockName: string,
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  if (!lockName) {
+    throw new TypeError("lockName is required and must be a non-empty string.");
+  }
+
+  return "locks" in navigator
+    ? withNativeLock(lockName, callback)
+    : withVendorLock(lockName, callback);
+}
+
+async function withNativeLock<T>(
+  lockName: string,
+  callback: () => T | Promise<T>,
+) {
+  try {
+    return await navigator.locks.request(
+      lockName,
+      { signal: AbortSignal.timeout(DEFAULT_LOCK_TIMEOUT_MS) },
+      callback,
+    );
+  } catch (error) {
+    if (error instanceof DOMException) {
+      switch (error.name) {
+        case "AbortError":
+          throw new LockError("AcquisitionTimeoutError", lockName, "Native");
+
+        case "InvalidStateError":
+        case "NotSupportedError":
+        case "SecurityError":
+        // These are documented but we currently don't handle them
+        // in any particular way and let them bubble up.
+      }
+    }
+
+    throw error;
+  }
+}
+
+async function withVendorLock<T>(
+  lockName: string,
+  callback: () => T | Promise<T>,
+) {
+  const lock = new Lock();
+
+  try {
+    if (await lock.acquireLock(lockName)) {
+      return await callback();
+    } else {
+      throw new LockError("AcquisitionTimeoutError", lockName, "Vendor");
+    }
+  } finally {
+    await lock.releaseLock(lockName);
+  }
+}
+
+class LockError extends Error {
+  constructor(
+    override readonly name: "AcquisitionTimeoutError",
+    readonly lockName: string,
+    type: "Native" | "Vendor",
+  ) {
+    const message = (() => {
+      switch (name) {
+        case "AcquisitionTimeoutError":
+          return `Lock acquisition timeout for "${lockName}".`;
+      }
+    })();
+
+    super(`${message} (${type})`);
+  }
+}

--- a/src/utils/locking.ts
+++ b/src/utils/locking.ts
@@ -50,7 +50,7 @@ async function withVendorLock<T>(
   const lock = new Lock();
 
   try {
-    if (await lock.acquireLock(lockName)) {
+    if (await lock.acquireLock(lockName, DEFAULT_LOCK_TIMEOUT_MS)) {
       return await callback();
     } else {
       throw new LockError("AcquisitionTimeoutError", lockName, "Vendor");

--- a/src/utils/locking.ts
+++ b/src/utils/locking.ts
@@ -66,13 +66,6 @@ export class LockError extends Error {
     readonly lockName: string,
     type: "Native" | "Vendor",
   ) {
-    const message = (() => {
-      switch (name) {
-        case "AcquisitionTimeoutError":
-          return `Lock acquisition timeout for "${lockName}".`;
-      }
-    })();
-
-    super(`${message} (${type})`);
+    super(`Lock acquisition timed out for "${lockName}" (${type})`);
   }
 }


### PR DESCRIPTION
The [Web Locks API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) should be more robust, so we should prefer it when it is available.

[Browser support is currently at 93%](https://caniuse.com/mdn-api_navigator_locks) so we'll likely _only_ support this locking mechanism in the future, but for now will fall back to the current "userspace" library to not change the browsers supported by the SDK.