### PR TITLE
Allow passing `organizationId` or `loginHint` when calling `signIn` or `signUp`

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -18,11 +18,11 @@ import { LoginRequiredError, RefreshError } from "./errors";
 import { withLock, LockError } from "./utils/locking";
 
 interface RedirectOptions {
-  type: "sign-in" | "sign-up";
-  state?: any;
+  context?: string;
   invitationToken?: string;
   passwordResetToken?: string;
-  context?: string;
+  state?: any;
+  type: "sign-in" | "sign-up";
 }
 
 type State = "INITIAL" | "AUTHENTICATING" | "AUTHENTICATED" | "ERROR";
@@ -100,24 +100,24 @@ export async function createClient(
   }
 
   async function _redirect({
-    type,
-    state,
     context,
     invitationToken,
     passwordResetToken,
+    state,
+    type,
   }: RedirectOptions) {
     const { codeVerifier, codeChallenge } = await createPkceChallenge();
     // store the code verifier in session storage for later use (after the redirect back from authkit)
     window.sessionStorage.setItem(storageKeys.codeVerifier, codeVerifier);
     const url = getAuthorizationUrl(_baseUrl, {
       clientId: _clientId,
-      redirectUri: _redirectUri,
-      screenHint: type,
-      context,
       codeChallenge,
       codeChallengeMethod: "S256",
+      context,
       invitationToken,
       passwordResetToken,
+      redirectUri: _redirectUri,
+      screenHint: type,
       state: state ? JSON.stringify(state) : undefined,
     });
 

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -20,6 +20,8 @@ import { withLock, LockError } from "./utils/locking";
 interface RedirectOptions {
   context?: string;
   invitationToken?: string;
+  loginHint?: string;
+  organizationId?: string;
   passwordResetToken?: string;
   state?: any;
   type: "sign-in" | "sign-up";
@@ -102,6 +104,8 @@ export async function createClient(
   async function _redirect({
     context,
     invitationToken,
+    loginHint,
+    organizationId,
     passwordResetToken,
     state,
     type,
@@ -115,6 +119,8 @@ export async function createClient(
       codeChallengeMethod: "S256",
       context,
       invitationToken,
+      loginHint,
+      organizationId,
       passwordResetToken,
       redirectUri: _redirectUri,
       screenHint: type,


### PR DESCRIPTION
These are parameters that are already respected by the underlying [Get Authorization URL API](https://workos.com/docs/reference/user-management/authentication/get-authorization-url), so this makes them available in these helper methods.