### PR TITLE
Convert `createClient` internals to a `class`

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -293,6 +293,31 @@ An authorization_code was supplied for a login which did not originate at the ap
     }
   }
 
+  #shouldRefresh() {
+    switch (this.#authkitClientState) {
+      case "INITIAL":
+      case "AUTHENTICATING":
+        return true;
+      case "ERROR":
+        return false;
+      case "AUTHENTICATED":
+        const accessToken = memoryStorage.getItem(storageKeys.accessToken) as
+          | string
+          | undefined;
+        const expiresAt = memoryStorage.getItem(storageKeys.expiresAt) as
+          | number
+          | undefined;
+
+        if (!accessToken || !expiresAt) {
+          return true;
+        }
+
+        const tokenRefreshBufferInSeconds = this.#refreshBufferInterval * 1000;
+        const refreshTime = expiresAt - tokenRefreshBufferInSeconds;
+        return refreshTime < Date.now();
+    }
+  }
+
   async #redirect({
     context,
     invitationToken,
@@ -324,31 +349,6 @@ An authorization_code was supplied for a login which did not originate at the ap
 
   #getAccessToken() {
     return memoryStorage.getItem(storageKeys.accessToken) as string | undefined;
-  }
-
-  #shouldRefresh() {
-    switch (this.#authkitClientState) {
-      case "INITIAL":
-      case "AUTHENTICATING":
-        return true;
-      case "ERROR":
-        return false;
-      case "AUTHENTICATED":
-        const accessToken = memoryStorage.getItem(storageKeys.accessToken) as
-          | string
-          | undefined;
-        const expiresAt = memoryStorage.getItem(storageKeys.expiresAt) as
-          | number
-          | undefined;
-
-        if (!accessToken || !expiresAt) {
-          return true;
-        }
-
-        const tokenRefreshBufferInSeconds = this.#refreshBufferInterval * 1000;
-        const refreshTime = expiresAt - tokenRefreshBufferInSeconds;
-        return refreshTime < Date.now();
-    }
   }
 
   get #useCookie() {

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -39,7 +39,7 @@ const ORGANIZATION_ID_SESSION_STORAGE_KEY = "workos_organization_id";
 
 const REFRESH_LOCK_NAME = "WORKOS_REFRESH_SESSION";
 
-class Client {
+export class Client {
   #state: State;
   #refreshTimer: ReturnType<typeof setTimeout> | undefined;
 

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -1,4 +1,8 @@
-import { CreateClientOptions, User } from "./interfaces";
+import {
+  AuthenticationResponse,
+  CreateClientOptions,
+  User,
+} from "./interfaces";
 import { NoClientIdProvidedException } from "./exceptions";
 import {
   authenticateWithCode,
@@ -35,114 +39,98 @@ const ORGANIZATION_ID_SESSION_STORAGE_KEY = "workos_organization_id";
 
 const REFRESH_LOCK_NAME = "WORKOS_REFRESH_SESSION";
 
-export async function createClient(
-  clientId: string,
-  options: CreateClientOptions = {},
-) {
-  if (!clientId) {
-    throw new NoClientIdProvidedException();
-  }
+class Client {
+  #authkitClientState: State;
+  #refreshTimer: ReturnType<typeof setTimeout> | undefined;
 
-  const {
-    apiHostname = DEFAULT_HOSTNAME,
-    https = true,
-    port,
-    redirectUri = window.origin,
-    devMode = location.hostname === "localhost" ||
-      location.hostname === "127.0.0.1",
-    // refresh if this is true
-    onBeforeAutoRefresh = () => {
-      return !document.hidden;
-    },
-    onRedirectCallback = (_: RedirectParams) => {},
-    onRefresh: _onRefresh,
-    onRefreshFailure: _onRefreshFailure,
-    refreshBufferInterval = 10,
-  } = options;
+  readonly #clientId: string;
+  readonly #redirectUri: string;
+  readonly #baseUrl: string;
+  readonly #devMode: boolean;
+  readonly #onBeforeAutoRefresh: () => boolean;
+  readonly #onRedirectCallback: (params: RedirectParams) => void;
+  readonly #onRefresh: ((response: AuthenticationResponse) => void) | undefined;
+  readonly #onRefreshFailure:
+    | ((params: { signIn: () => Promise<void> }) => void)
+    | undefined;
+  readonly #refreshBufferInterval: number;
 
-  const _clientId = clientId;
-  const _redirectUri = redirectUri;
-  const _baseUrl = `${https ? "https" : "http"}://${apiHostname}${
-    port ? `:${port}` : ""
-  }`;
-  const _useCookie = !devMode;
-  let _authkitClientState: State = "INITIAL";
-
-  const _shouldRefresh = () => {
-    switch (_authkitClientState) {
-      case "INITIAL":
-      case "AUTHENTICATING":
-        return true;
-      case "ERROR":
-        return false;
-      case "AUTHENTICATED":
-        const accessToken = memoryStorage.getItem(storageKeys.accessToken) as
-          | string
-          | undefined;
-        const expiresAt = memoryStorage.getItem(storageKeys.expiresAt) as
-          | number
-          | undefined;
-
-        if (!accessToken || !expiresAt) {
-          return true;
-        }
-
-        const tokenRefreshBufferInSeconds = refreshBufferInterval * 1000;
-        const refreshTime = expiresAt - tokenRefreshBufferInSeconds;
-        return refreshTime < Date.now();
+  constructor(
+    clientId: string,
+    {
+      apiHostname = DEFAULT_HOSTNAME,
+      https = true,
+      port,
+      redirectUri = window.origin,
+      devMode = location.hostname === "localhost" ||
+        location.hostname === "127.0.0.1",
+      // refresh if this is true
+      onBeforeAutoRefresh = () => {
+        return !document.hidden;
+      },
+      onRedirectCallback = (_: RedirectParams) => {},
+      onRefresh,
+      onRefreshFailure,
+      refreshBufferInterval = 10,
+    }: CreateClientOptions = {},
+  ) {
+    if (!clientId) {
+      throw new NoClientIdProvidedException();
     }
-  };
 
-  async function signIn(opts: Omit<RedirectOptions, "type"> = {}) {
-    return _redirect({ ...opts, type: "sign-in" });
+    this.#devMode = devMode;
+    this.#clientId = clientId;
+    this.#redirectUri = redirectUri;
+    this.#baseUrl = `${https ? "https" : "http"}://${apiHostname}${
+      port ? `:${port}` : ""
+    }`;
+    this.#authkitClientState = "INITIAL";
+    this.#onBeforeAutoRefresh = onBeforeAutoRefresh;
+    this.#onRedirectCallback = onRedirectCallback;
+    this.#onRefresh = onRefresh;
+    this.#onRefreshFailure = onRefreshFailure;
+    this.#refreshBufferInterval = refreshBufferInterval;
   }
 
-  async function signUp(opts: Omit<RedirectOptions, "type"> = {}) {
-    return _redirect({ ...opts, type: "sign-up" });
-  }
+  async initialize() {
+    if (this.#authkitClientState !== "INITIAL") {
+      return;
+    }
 
-  async function _redirect({
-    context,
-    invitationToken,
-    loginHint,
-    organizationId,
-    passwordResetToken,
-    state,
-    type,
-  }: RedirectOptions) {
-    const { codeVerifier, codeChallenge } = await createPkceChallenge();
-    // store the code verifier in session storage for later use (after the redirect back from authkit)
-    window.sessionStorage.setItem(storageKeys.codeVerifier, codeVerifier);
-    const url = getAuthorizationUrl(_baseUrl, {
-      clientId: _clientId,
-      codeChallenge,
-      codeChallengeMethod: "S256",
-      context,
-      invitationToken,
-      loginHint,
-      organizationId,
-      passwordResetToken,
-      redirectUri: _redirectUri,
-      screenHint: type,
-      state: state ? JSON.stringify(state) : undefined,
-    });
-
-    window.location.assign(url);
-  }
-
-  function getUser() {
-    const user = memoryStorage.getItem(storageKeys.user);
-    return user ? (user as User) : null;
-  }
-
-  function _getAccessToken() {
-    return memoryStorage.getItem(storageKeys.accessToken) as string | undefined;
-  }
-
-  async function getAccessToken(): Promise<string> {
-    if (_shouldRefresh()) {
+    const searchParams = new URLSearchParams(window.location.search);
+    if (isRedirectCallback(this.#redirectUri, searchParams)) {
+      await this.#handleCallback();
+    } else {
       try {
-        await refreshSession();
+        await this.#refreshSession();
+        this.#scheduleAutomaticRefresh();
+      } catch {
+        // this is expected to fail if a user doesn't
+        // have a session. do nothing.
+      }
+    }
+  }
+
+  async signIn(opts: Omit<RedirectOptions, "type"> = {}) {
+    return this.#redirect({ ...opts, type: "sign-in" });
+  }
+
+  async signUp(opts: Omit<RedirectOptions, "type"> = {}) {
+    return this.#redirect({ ...opts, type: "sign-up" });
+  }
+
+  signOut() {
+    const url = getLogoutUrl(this.#baseUrl);
+    if (url) {
+      removeSessionData({ devMode: this.#devMode });
+      window.location.assign(url);
+    }
+  }
+
+  async getAccessToken(): Promise<string> {
+    if (this.#shouldRefresh()) {
+      try {
+        await this.#refreshSession();
       } catch (err) {
         if (err instanceof RefreshError) {
           throw new LoginRequiredError();
@@ -152,7 +140,7 @@ export async function createClient(
       }
     }
 
-    const accessToken = _getAccessToken();
+    const accessToken = this.#getAccessToken();
     if (!accessToken) {
       throw new LoginRequiredError();
     }
@@ -160,42 +148,18 @@ export async function createClient(
     return accessToken;
   }
 
-  let _refreshTimer: ReturnType<typeof setTimeout> | undefined;
-  const _scheduleAutomaticRefresh = () => {
-    _refreshTimer = setTimeout(() => {
-      if (_shouldRefresh() && onBeforeAutoRefresh()) {
-        refreshSession()
-          .catch((e) => {
-            console.error(e);
-          })
-          .then(_scheduleAutomaticRefresh);
-      } else {
-        _scheduleAutomaticRefresh();
-      }
-    }, 1000);
-  };
-
-  async function _initialize() {
-    if (_authkitClientState !== "INITIAL") {
-      return;
-    }
-
-    const searchParams = new URLSearchParams(window.location.search);
-    if (isRedirectCallback(redirectUri, searchParams)) {
-      await _handleCallback();
-    } else {
-      try {
-        await refreshSession();
-        _scheduleAutomaticRefresh();
-      } catch {
-        // this is expected to fail if a user doesn't
-        // have a session. do nothing.
-      }
-    }
+  getUser() {
+    const user = memoryStorage.getItem(storageKeys.user);
+    return user ? (user as User) : null;
   }
 
-  async function _handleCallback() {
-    if (_authkitClientState !== "INITIAL") {
+  dispose() {
+    clearTimeout(this.#refreshTimer);
+    memoryStorage.reset();
+  }
+
+  async #handleCallback() {
+    if (this.#authkitClientState !== "INITIAL") {
       return;
     }
 
@@ -203,7 +167,7 @@ export async function createClient(
     const code = url.searchParams.get("code");
     const stateParam = url.searchParams.get("state");
     const state = stateParam ? JSON.parse(stateParam) : undefined;
-    _authkitClientState = "AUTHENTICATING";
+    this.#authkitClientState = "AUTHENTICATING";
 
     // grab the previously stored code verifier from session storage
     const codeVerifier = window.sessionStorage.getItem(
@@ -214,26 +178,26 @@ export async function createClient(
       if (codeVerifier) {
         try {
           const authenticationResponse = await authenticateWithCode({
-            baseUrl: _baseUrl,
-            clientId: _clientId,
+            baseUrl: this.#baseUrl,
+            clientId: this.#clientId,
             code,
             codeVerifier,
-            useCookie: _useCookie,
+            useCookie: this.#useCookie,
           });
 
           if (authenticationResponse) {
-            _authkitClientState = "AUTHENTICATED";
-            _scheduleAutomaticRefresh();
-            setSessionData(authenticationResponse, { devMode });
-            _onRefresh && _onRefresh(authenticationResponse);
-            onRedirectCallback({ state, ...authenticationResponse });
+            this.#authkitClientState = "AUTHENTICATED";
+            this.#scheduleAutomaticRefresh();
+            setSessionData(authenticationResponse, { devMode: this.#devMode });
+            this.#onRefresh && this.#onRefresh(authenticationResponse);
+            this.#onRedirectCallback({ state, ...authenticationResponse });
           }
         } catch (error) {
-          _authkitClientState = "ERROR";
+          this.#authkitClientState = "ERROR";
           console.error(error);
         }
       } else {
-        _authkitClientState = "ERROR";
+        this.#authkitClientState = "ERROR";
         console.error(`Couldn't exchange code.
 
 An authorization_code was supplied for a login which did not originate at the application. This could happen for various reasons:
@@ -251,11 +215,23 @@ An authorization_code was supplied for a login which did not originate at the ap
     window.history.replaceState({}, "", cleanUrl);
   }
 
-  async function refreshSession({
-    organizationId,
-  }: { organizationId?: string } = {}) {
-    const beginningState = _authkitClientState;
-    _authkitClientState = "AUTHENTICATING";
+  async #scheduleAutomaticRefresh() {
+    this.#refreshTimer = setTimeout(() => {
+      if (this.#shouldRefresh() && this.#onBeforeAutoRefresh()) {
+        this.#refreshSession()
+          .catch((e) => {
+            console.error(e);
+          })
+          .then(() => this.#scheduleAutomaticRefresh);
+      } else {
+        this.#scheduleAutomaticRefresh();
+      }
+    }, 1000);
+  }
+
+  async #refreshSession({ organizationId }: { organizationId?: string } = {}) {
+    const beginningState = this.#authkitClientState;
+    this.#authkitClientState = "AUTHENTICATING";
 
     try {
       await withLock(REFRESH_LOCK_NAME, async () => {
@@ -265,7 +241,7 @@ An authorization_code was supplied for a login which did not originate at the ap
             organizationId,
           );
         } else {
-          const accessToken = _getAccessToken();
+          const accessToken = this.#getAccessToken();
           if (accessToken) {
             organizationId = getClaims(accessToken)?.org_id;
           } else {
@@ -276,16 +252,16 @@ An authorization_code was supplied for a login which did not originate at the ap
         }
 
         const authenticationResponse = await authenticateWithRefreshToken({
-          baseUrl: _baseUrl,
-          clientId: _clientId,
-          refreshToken: getRefreshToken({ devMode }),
+          baseUrl: this.#baseUrl,
+          clientId: this.#clientId,
+          refreshToken: getRefreshToken({ devMode: this.#devMode }),
           organizationId,
-          useCookie: _useCookie,
+          useCookie: this.#useCookie,
         });
 
-        _authkitClientState = "AUTHENTICATED";
-        setSessionData(authenticationResponse, { devMode });
-        _onRefresh && _onRefresh(authenticationResponse);
+        this.#authkitClientState = "AUTHENTICATED";
+        setSessionData(authenticationResponse, { devMode: this.#devMode });
+        this.#onRefresh && this.#onRefresh(authenticationResponse);
       });
     } catch (error) {
       if (
@@ -295,50 +271,98 @@ An authorization_code was supplied for a login which did not originate at the ap
         console.warn("Couldn't acquire refresh lock.");
 
         // preserving the original state so that we can try again next time
-        _authkitClientState = beginningState;
+        this.#authkitClientState = beginningState;
 
         return;
       }
 
       console.error(error);
       if (error instanceof RefreshError) {
-        removeSessionData({ devMode });
+        removeSessionData({ devMode: this.#devMode });
         // fire the refresh failure UNLESS this is the initial refresh attempt
         // (the initial refresh is expected to fail if a user has not logged in
         // ever or recently)
         beginningState !== "INITIAL" &&
-          _onRefreshFailure &&
-          _onRefreshFailure({ signIn: signIn });
+          this.#onRefreshFailure &&
+          this.#onRefreshFailure({ signIn: this.signIn.bind(this) });
       }
       // TODO: if a lock couldn't be acquired... that's not a fatal error.
       // maybe that's another state?
-      _authkitClientState = "ERROR";
+      this.#authkitClientState = "ERROR";
       throw error;
     }
   }
 
-  function signOut() {
-    const url = getLogoutUrl(_baseUrl);
-    if (url) {
-      removeSessionData({ devMode });
-      window.location.assign(url);
+  async #redirect({
+    context,
+    invitationToken,
+    loginHint,
+    organizationId,
+    passwordResetToken,
+    state,
+    type,
+  }: RedirectOptions) {
+    const { codeVerifier, codeChallenge } = await createPkceChallenge();
+    // store the code verifier in session storage for later use (after the redirect back from authkit)
+    window.sessionStorage.setItem(storageKeys.codeVerifier, codeVerifier);
+    const url = getAuthorizationUrl(this.#baseUrl, {
+      clientId: this.#clientId,
+      codeChallenge,
+      codeChallengeMethod: "S256",
+      context,
+      invitationToken,
+      loginHint,
+      organizationId,
+      passwordResetToken,
+      redirectUri: this.#redirectUri,
+      screenHint: type,
+      state: state ? JSON.stringify(state) : undefined,
+    });
+
+    window.location.assign(url);
+  }
+
+  #getAccessToken() {
+    return memoryStorage.getItem(storageKeys.accessToken) as string | undefined;
+  }
+
+  #shouldRefresh() {
+    switch (this.#authkitClientState) {
+      case "INITIAL":
+      case "AUTHENTICATING":
+        return true;
+      case "ERROR":
+        return false;
+      case "AUTHENTICATED":
+        const accessToken = memoryStorage.getItem(storageKeys.accessToken) as
+          | string
+          | undefined;
+        const expiresAt = memoryStorage.getItem(storageKeys.expiresAt) as
+          | number
+          | undefined;
+
+        if (!accessToken || !expiresAt) {
+          return true;
+        }
+
+        const tokenRefreshBufferInSeconds = this.#refreshBufferInterval * 1000;
+        const refreshTime = expiresAt - tokenRefreshBufferInSeconds;
+        return refreshTime < Date.now();
     }
   }
 
-  function dispose() {
-    clearTimeout(_refreshTimer);
-    memoryStorage.reset();
+  get #useCookie() {
+    return !this.#devMode;
   }
+}
 
-  // we wait for the client to be initialized (redirect callback or refresh token)
-  await _initialize();
+export async function createClient(
+  clientId: string,
+  options: CreateClientOptions = {},
+) {
+  const client = new Client(clientId, options);
 
-  return {
-    signIn,
-    signUp,
-    getUser,
-    getAccessToken,
-    signOut,
-    dispose,
-  };
+  await client.initialize();
+
+  return client;
 }


### PR DESCRIPTION
This class fulfills the same interface that the previous anonymous object returned by `createClient` did, so these should not be a breaking change.

In the future, we may want to consider removing `createClient` completely and have callers instantiate `Client` directly (or maybe call a factory/`static` method like `Client.initialize`).