### PR TITLE
stop `console.error`ing on expected errors

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -284,9 +284,6 @@ describe("create-client", () => {
 
       describe("when the current session is not authenticated", () => {
         it("returns `null`", async () => {
-          const consoleErrorSpy = jest
-            .spyOn(console, "error")
-            .mockImplementation();
           const scope = nock("https://api.workos.com")
             .post("/user_management/authenticate", {
               client_id: "client_123abc",
@@ -300,9 +297,6 @@ describe("create-client", () => {
           const user = client.getUser();
 
           expect(user).toBeNull();
-          expect(consoleErrorSpy.mock.calls).toEqual([
-            [expect.any(RefreshError)],
-          ]);
           scope.done();
         });
       });
@@ -325,9 +319,6 @@ describe("create-client", () => {
 
       describe("when the current session is not authenticated", () => {
         it("throws a `LoginRequiredError`", async () => {
-          const consoleErrorSpy = jest
-            .spyOn(console, "error")
-            .mockImplementation();
           const scope = nock("https://api.workos.com")
             .post("/user_management/authenticate", {
               client_id: "client_123abc",
@@ -341,10 +332,6 @@ describe("create-client", () => {
           await expect(client.getAccessToken()).rejects.toThrow(
             LoginRequiredError,
           );
-
-          expect(consoleErrorSpy.mock.calls).toEqual([
-            [expect.any(RefreshError)],
-          ]);
           scope.done();
         });
       });
@@ -391,7 +378,7 @@ describe("create-client", () => {
           })
           .reply(401, {});
         const signInSpy = jest.spyOn(client, "signIn").mockImplementation();
-        jest.spyOn(console, "error").mockImplementation();
+        jest.spyOn(console, "debug").mockImplementation();
 
         await client.switchToOrganization({
           organizationId,

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -220,7 +220,7 @@ An authorization_code was supplied for a login which did not originate at the ap
       if (this.#shouldRefresh() && this.#onBeforeAutoRefresh()) {
         this.#refreshSession()
           .catch((e) => {
-            console.error(e);
+            console.debug(e);
           })
           .then(() => this.#scheduleAutomaticRefresh);
       } else {
@@ -300,7 +300,10 @@ An authorization_code was supplied for a login which did not originate at the ap
         return;
       }
 
-      console.error(error);
+      if (beginningState !== "INITIAL") {
+        console.debug(error);
+      }
+
       if (error instanceof RefreshError) {
         removeSessionData({ devMode: this.#devMode });
         // fire the refresh failure UNLESS this is the initial refresh attempt
@@ -310,8 +313,6 @@ An authorization_code was supplied for a login which did not originate at the ap
           this.#onRefreshFailure &&
           this.#onRefreshFailure({ signIn: this.signIn.bind(this) });
       }
-      // TODO: if a lock couldn't be acquired... that's not a fatal error.
-      // maybe that's another state?
       this.#state = "ERROR";
       throw error;
     }


### PR DESCRIPTION
Fixes #52.

Refresh errors are expected to happen (session ends, user is not logged in yet, etc.). This is sometimes useful information when debugging, so we should use `console.debug` instead of `console.error`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
