### PR TITLE
piggy-back on current authentication request

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,6 @@
 export class AuthKitError extends Error {}
 export class RefreshError extends AuthKitError {}
+export class CodeExchangeError extends AuthKitError {}
 export class LoginRequiredError extends AuthKitError {
   readonly message: string = "No access token available";
 }

--- a/src/utils/authenticate-with-code.ts
+++ b/src/utils/authenticate-with-code.ts
@@ -1,3 +1,4 @@
+import { CodeExchangeError } from "../errors";
 import { AuthenticationResponseRaw } from "../interfaces";
 import { deserializeAuthenticationResponse } from "../serializers";
 
@@ -31,7 +32,8 @@ export async function authenticateWithCode(
   if (response.ok) {
     const data = (await response.json()) as AuthenticationResponseRaw;
     return deserializeAuthenticationResponse(data);
-  } else {
-    console.log("error", await response.json());
   }
+
+  const error = await response.json();
+  throw new CodeExchangeError(error.error_description);
 }


### PR DESCRIPTION
It was previously possible for multiple outbound /user_management/authenticate requests to happen simultaneously if `getAccessToken` was called multiple times when the current access token had expired.

This PR moves the authenticate request into the client state so that subsequent calls to `getAccessToken` can just await the existing one.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
