### PR TITLE
omit refreshToken from `onRefresh`

### DIFF
--- a/src/interfaces/authentication-response.interface.ts
+++ b/src/interfaces/authentication-response.interface.ts
@@ -9,6 +9,8 @@ export interface AuthenticationResponse {
   impersonator?: Impersonator;
 }
 
+export type OnRefreshResponse = Omit<AuthenticationResponse, "refreshToken">;
+
 export interface AuthenticationResponseRaw {
   user: UserRaw;
   access_token: string;

--- a/src/interfaces/create-client-options.interface.ts
+++ b/src/interfaces/create-client-options.interface.ts
@@ -1,4 +1,7 @@
-import { AuthenticationResponse } from "./authentication-response.interface";
+import {
+  AuthenticationResponse,
+  OnRefreshResponse,
+} from "./authentication-response.interface";
 import { createClient } from "../create-client";
 
 export interface CreateClientOptions {
@@ -14,7 +17,7 @@ export interface CreateClientOptions {
   devMode?: boolean;
   onRedirectCallback?: (_: RedirectParams) => void;
   onBeforeAutoRefresh?: () => boolean;
-  onRefresh?: (_: AuthenticationResponse) => void;
+  onRefresh?: (_: OnRefreshResponse) => void;
   onRefreshFailure?: (args: {
     signIn: Awaited<ReturnType<typeof createClient>>["signIn"];
   }) => void;


### PR DESCRIPTION
The SDK owns the refresh token. There is no useful reason to expose it to the application.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
