### PR TITLE
only attempt initial refresh when likely to succeed

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -19,6 +19,11 @@ describe("create-client", () => {
     sessionStorage.removeItem(storageKeys.codeVerifier);
     sessionStorage.removeItem(ORGANIZATION_ID_SESSION_STORAGE_KEY);
     localStorage.removeItem(storageKeys.refreshToken);
+
+    // assume we have a session already for all these tests
+    jest
+      .spyOn(document, "cookie", "get")
+      .mockReturnValue(`workos-has-session=1`);
   });
 
   afterEach(() => {

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -107,7 +107,7 @@ export class Client {
     const searchParams = new URLSearchParams(window.location.search);
     if (isRedirectCallback(this.#redirectUri, searchParams)) {
       await this.#handleCallback();
-    } else {
+    } else if (document.cookie.includes("workos-has-session=")) {
       try {
         await this.#refreshSession();
         this.#scheduleAutomaticRefresh();


### PR DESCRIPTION
We now set a javascript-accessible `workos-has-session` cookie when the user is logged in. We don't need to attempt to refresh if that cookie is not present.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
