### PR TITLE
only transition to ERROR state for permanent errors

### DIFF
--- a/src/utils/authenticate-with-refresh-token.ts
+++ b/src/utils/authenticate-with-refresh-token.ts
@@ -36,6 +36,8 @@ export async function authenticateWithRefreshToken({
     const data = (await response.json()) as AuthenticationResponseRaw;
     return deserializeAuthenticationResponse(data);
   } else {
+    // TODO: a 500 error should be different than a 400 error (500s should
+    // continue to retry?)
     const error = (await response.json()) as any;
     throw new RefreshError(error.error_description);
   }


### PR DESCRIPTION
The ERROR state is meant for terminal errors (like when the session has ended). It should not be used for things like `fetch` or tab-lock errors. This will allow subsequent `getAccessToken` calls to successfully obtain an access token.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
