### PR TITLE
don't transition to error state for fetch/etc. errors

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -334,8 +334,16 @@ An authorization_code was supplied for a login which did not originate at the ap
         beginningState.tag !== "INITIAL" &&
           this.#onRefreshFailure &&
           this.#onRefreshFailure({ signIn: this.signIn.bind(this) });
+
+        this.#state = { tag: "ERROR" };
+      } else {
+        // transitioning into the AUTHENTICATED state ensures that we will
+        // attempt to refresh the token on future getAccessToken calls()
+        //
+        // this could maybe be a new state for clarity? TEMPORARY_ERROR?
+        this.#state = { tag: "AUTHENTICATED" };
       }
-      this.#state = { tag: "ERROR" };
+
       throw error;
     }
   }


### PR DESCRIPTION
The ERROR state is meant to indicate terminal errors (like the session being over). authkit-js will not attempt to retrieve new tokens after when in an ERROR state.

Temporary errors (like `fetch` or tab-lock errors) should _not_ move to the error state. This allows future calls to `getAccessToken` to attempt to retrieve a new token.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
