### PR TITLE
v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-js",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-js",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "AuthKit SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { createClient } from "./create-client";
 export { getClaims } from "./utils/session-data";
-export { User, AuthenticationResponse } from "./interfaces";
+export { User, AuthenticationResponse, OnRefreshResponse } from "./interfaces";
 export { AuthKitError, LoginRequiredError } from "./errors";


### PR DESCRIPTION
changes:

* avoids initial refresh when user has no session (#61)

fixes:

* throws error instead of returning stale access tokens when offline
  (#63)
* properly exports `OnRefreshResponse` type


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"better-fetch-error-handling","parentHead":"fbadeb6fa913bbfec124d4d1998b9b7020b07e7c","parentPull":63,"trunk":"main"}
```
-->
