### PR TITLE
fix initial refresh in dev mode

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -98,7 +98,10 @@ export class Client {
     const searchParams = new URLSearchParams(window.location.search);
     if (isRedirectCallback(this.#redirectUri, searchParams)) {
       await this.#handleCallback();
-    } else if (document.cookie.includes("workos-has-session=")) {
+    } else if (
+      document.cookie.includes("workos-has-session=") ||
+      getRefreshToken({ devMode: this.#devMode })
+    ) {
       try {
         await this.#refreshSession();
         this.#scheduleAutomaticRefresh();


### PR DESCRIPTION
This fixes a regression when running in devMode. The session wasn't automatically attempting to refresh on page load as it should.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
