### PR TITLE
Improve compatibility with hybrid mobile apps

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -487,7 +487,7 @@ describe("create-client", () => {
           global.fetch = mockFetch;
 
           try {
-            await client.signOut({ noRedirect: true });
+            await client.signOut({ navigate: false });
 
             // Location.assign should not be called
             expect(jest.mocked(location.assign)).not.toHaveBeenCalled();
@@ -528,7 +528,7 @@ describe("create-client", () => {
           try {
             await client.signOut({
               returnTo: "https://example.com",
-              noRedirect: true,
+              navigate: false,
             });
 
             // Location.assign should not be called
@@ -606,7 +606,7 @@ describe("create-client", () => {
             global.fetch = mockFetch;
 
             try {
-              await client.signOut({ noRedirect: true });
+              await client.signOut({ navigate: false });
               expect(localStorage.getItem(storageKeys.refreshToken)).toBeNull();
               scope.done();
             } finally {

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -326,6 +326,94 @@ describe("create-client", () => {
       });
     });
 
+    describe("getSignInUrl", () => {
+      beforeEach(() => {
+        mockLocation();
+      });
+
+      afterEach(() => {
+        restoreLocation();
+      });
+
+      it("generates a PKCE challenge and returns the AuthKit sign-in page URL", async () => {
+        const { scope } = nockRefresh();
+        expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeNull();
+
+        client = await createClient("client_123abc", {
+          redirectUri: "https://example.com/",
+        });
+        const signInUrl = await client.getSignInUrl();
+        const url = new URL(signInUrl);
+
+        // Location.assign should not be called
+        expect(jest.mocked(location.assign)).not.toHaveBeenCalled();
+        expect({
+          url,
+          searchParams: Object.fromEntries(url.searchParams.entries()),
+        }).toEqual({
+          url: expect.objectContaining({
+            origin: "https://api.workos.com",
+            pathname: "/user_management/authorize",
+          }),
+          searchParams: {
+            client_id: "client_123abc",
+            code_challenge: expect.any(String),
+            code_challenge_method: "S256",
+            provider: "authkit",
+            redirect_uri: "https://example.com/",
+            response_type: "code",
+            screen_hint: "sign-in",
+          },
+        });
+        expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeDefined();
+        scope.done();
+      });
+    });
+
+    describe("getSignUpUrl", () => {
+      beforeEach(() => {
+        mockLocation();
+      });
+
+      afterEach(() => {
+        restoreLocation();
+      });
+
+      it("generates a PKCE challenge and returns the AuthKit sign-up page URL", async () => {
+        const { scope } = nockRefresh();
+        expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeNull();
+
+        client = await createClient("client_123abc", {
+          redirectUri: "https://example.com/",
+        });
+        const signUpUrl = await client.getSignUpUrl();
+        const url = new URL(signUpUrl);
+
+        // Location.assign should not be called
+        expect(jest.mocked(location.assign)).not.toHaveBeenCalled();
+        expect({
+          url,
+          searchParams: Object.fromEntries(url.searchParams.entries()),
+        }).toEqual({
+          url: expect.objectContaining({
+            origin: "https://api.workos.com",
+            pathname: "/user_management/authorize",
+          }),
+          searchParams: {
+            client_id: "client_123abc",
+            code_challenge: expect.any(String),
+            code_challenge_method: "S256",
+            provider: "authkit",
+            redirect_uri: "https://example.com/",
+            response_type: "code",
+            screen_hint: "sign-up",
+          },
+        });
+        expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeDefined();
+        scope.done();
+      });
+    });
+
     describe("signOut", () => {
       beforeEach(() => {
         mockLocation();

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -526,7 +526,10 @@ describe("create-client", () => {
           global.fetch = mockFetch;
 
           try {
-            await client.signOut({ returnTo: "https://example.com", noRedirect: true });
+            await client.signOut({
+              returnTo: "https://example.com",
+              noRedirect: true,
+            });
 
             // Location.assign should not be called
             expect(jest.mocked(location.assign)).not.toHaveBeenCalled();

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -472,7 +472,7 @@ describe("create-client", () => {
         });
       });
 
-      describe("when the `noRedirect` option is provided", () => {
+      describe("when the `navigate` option is set to false", () => {
         it("makes a fetch request instead of redirecting", async () => {
           const { scope } = nockRefresh();
 
@@ -589,7 +589,7 @@ describe("create-client", () => {
           });
         });
 
-        describe("when `noRedirect` is true", () => {
+        describe("when the `navigate` is set to false", () => {
           it("clears the tokens", async () => {
             localStorage.setItem(storageKeys.refreshToken, "refresh_token");
             const { scope } = nockRefresh({ devMode: true });

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -136,7 +136,7 @@ export class Client {
     window.location.assign(url);
   }
 
-  signOut(options?: { returnTo: string }): void {
+  signOut(options?: { returnTo?: string, noRedirect?: boolean }): void {
     const accessToken = memoryStorage.getItem(storageKeys.accessToken);
     if (typeof accessToken !== "string") return;
     const { sid: sessionId } = getClaims(accessToken);
@@ -148,7 +148,11 @@ export class Client {
 
     if (url) {
       removeSessionData({ devMode: this.#devMode });
-      window.location.assign(url);
+      if (options?.noRedirect) {
+        fetch(url)
+      } else {
+        window.location.assign(url);
+      }
     }
   }
 

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -115,13 +115,25 @@ export class Client {
       }
     }
   }
+  
+  async getSignInUrl(opts: Omit<RedirectOptions, "type"> = {}) {
+    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-in" });
+    return url
+  }
 
+  async getSignUpUrl(opts: Omit<RedirectOptions, "type"> = {}) {
+    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-up" });
+    return url
+  }
+  
   async signIn(opts: Omit<RedirectOptions, "type"> = {}) {
-    return this.#redirect({ ...opts, type: "sign-in" });
+    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-in" });
+    window.location.assign(url);
   }
 
   async signUp(opts: Omit<RedirectOptions, "type"> = {}) {
-    return this.#redirect({ ...opts, type: "sign-up" });
+    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-up" });
+    window.location.assign(url);
   }
 
   signOut(options?: { returnTo: string }): void {
@@ -382,7 +394,7 @@ An authorization_code was supplied for a login which did not originate at the ap
     }
   }
 
-  async #redirect({
+  async #getAuthorizationUrl({
     context,
     invitationToken,
     loginHint,
@@ -407,7 +419,7 @@ An authorization_code was supplied for a login which did not originate at the ap
       state: state ? JSON.stringify(state) : undefined,
     });
 
-    window.location.assign(url);
+    return url
   }
 
   #getAccessToken() {

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -115,17 +115,17 @@ export class Client {
       }
     }
   }
-  
+
   async getSignInUrl(opts: Omit<RedirectOptions, "type"> = {}) {
     const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-in" });
-    return url
+    return url;
   }
 
   async getSignUpUrl(opts: Omit<RedirectOptions, "type"> = {}) {
     const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-up" });
-    return url
+    return url;
   }
-  
+
   async signIn(opts: Omit<RedirectOptions, "type"> = {}) {
     const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-in" });
     window.location.assign(url);
@@ -136,7 +136,7 @@ export class Client {
     window.location.assign(url);
   }
 
-  signOut(options?: { returnTo?: string, noRedirect?: boolean }): void {
+  signOut(options?: { returnTo?: string; noRedirect?: boolean }): void {
     const accessToken = memoryStorage.getItem(storageKeys.accessToken);
     if (typeof accessToken !== "string") return;
     const { sid: sessionId } = getClaims(accessToken);
@@ -149,7 +149,7 @@ export class Client {
     if (url) {
       removeSessionData({ devMode: this.#devMode });
       if (options?.noRedirect) {
-        fetch(url)
+        fetch(url);
       } else {
         window.location.assign(url);
       }
@@ -423,7 +423,7 @@ An authorization_code was supplied for a login which did not originate at the ap
       state: state ? JSON.stringify(state) : undefined,
     });
 
-    return url
+    return url;
   }
 
   #getAccessToken() {

--- a/src/utils/is-redirect-callback.test.ts
+++ b/src/utils/is-redirect-callback.test.ts
@@ -51,4 +51,66 @@ describe("isRedirectCallback", () => {
       expect(result).toBe(false);
     });
   });
+
+  describe("when using redirect URIs in hybrid mobile app (e.g. Capacitor)", () => {
+    /**
+     * These tests ensure the function works for hybrid apps built with Capacitor.
+     * For Android, the app uses http://localhost/callback as the current URL.
+     * For iOS, the app uses capacitor://localhost/callback as the current URL.
+     * See https://ionicframework.com/docs/troubleshooting/cors
+     * The redirectUri remains https://example.com/callback. 
+     * In the mobile app context, and the redirectUri is deep linked towards the app.
+     */
+    it("returns true when current location is http://localhost/callback and redirectUri is https://example.com/callback (Android)", () => {
+      const originalLocation = window.location;
+      const androidLocation = new URL('http://localhost/callback');
+
+      delete (window as any).location;
+      Object.defineProperty(window, 'location', {
+        value: androidLocation,
+        writable: true,
+        configurable: true
+      });
+      
+      const redirectUri = "https://example.com/callback";
+      const searchParams = new URLSearchParams(Object.entries({ code: "123" }));
+
+      const result = isRedirectCallback(redirectUri, searchParams);
+      
+      delete (window as any).location;
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("returns true when current location is capacitor://localhost/callback and redirectUri is https://example.com/callback (iOS)", () => {
+      const originalLocation = window.location;
+      const iOSLocation = new URL('capacitor://localhost/callback');
+      
+      delete (window as any).location;
+      Object.defineProperty(window, 'location', {
+        value: iOSLocation,
+        writable: true,
+        configurable: true
+      });
+
+      const redirectUri = "https://example.com/callback";
+      const searchParams = new URLSearchParams(Object.entries({ code: "123" }));
+
+      const result = isRedirectCallback(redirectUri, searchParams);
+      
+      delete (window as any).location;
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true
+      });
+
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/src/utils/is-redirect-callback.test.ts
+++ b/src/utils/is-redirect-callback.test.ts
@@ -16,10 +16,15 @@ describe("isRedirectCallback", () => {
 
   describe('when the given redirect URI ends with a "/"', () => {
     it("returns true when the current location otherwise matches without the slash", () => {
+      const originalPath = window.location.pathname;
+      window.history.replaceState({}, "", "/callback/");
+      
       const redirectUri = "https://example.com/callback";
       const searchParams = new URLSearchParams(Object.entries({ code: "123" }));
 
       const result = isRedirectCallback(redirectUri, searchParams);
+
+      window.history.replaceState({}, "", originalPath);
 
       expect(result).toBe(true);
     });

--- a/src/utils/is-redirect-callback.test.ts
+++ b/src/utils/is-redirect-callback.test.ts
@@ -18,7 +18,7 @@ describe("isRedirectCallback", () => {
     it("returns true when the current location otherwise matches without the slash", () => {
       const originalPath = window.location.pathname;
       window.history.replaceState({}, "", "/callback/");
-      
+
       const redirectUri = "https://example.com/callback";
       const searchParams = new URLSearchParams(Object.entries({ code: "123" }));
 
@@ -58,30 +58,30 @@ describe("isRedirectCallback", () => {
      * For Android, the app uses http://localhost/callback as the current URL.
      * For iOS, the app uses capacitor://localhost/callback as the current URL.
      * See https://ionicframework.com/docs/troubleshooting/cors
-     * The redirectUri remains https://example.com/callback. 
+     * The redirectUri remains https://example.com/callback.
      * In the mobile app context, and the redirectUri is deep linked towards the app.
      */
     it("returns true when current location is http://localhost/callback and redirectUri is https://example.com/callback (Android)", () => {
       const originalLocation = window.location;
-      const androidLocation = new URL('http://localhost/callback');
+      const androidLocation = new URL("http://localhost/callback");
 
       delete (window as any).location;
-      Object.defineProperty(window, 'location', {
+      Object.defineProperty(window, "location", {
         value: androidLocation,
         writable: true,
-        configurable: true
+        configurable: true,
       });
-      
+
       const redirectUri = "https://example.com/callback";
       const searchParams = new URLSearchParams(Object.entries({ code: "123" }));
 
       const result = isRedirectCallback(redirectUri, searchParams);
-      
+
       delete (window as any).location;
-      Object.defineProperty(window, 'location', {
+      Object.defineProperty(window, "location", {
         value: originalLocation,
         writable: true,
-        configurable: true
+        configurable: true,
       });
 
       expect(result).toBe(true);
@@ -89,25 +89,25 @@ describe("isRedirectCallback", () => {
 
     it("returns true when current location is capacitor://localhost/callback and redirectUri is https://example.com/callback (iOS)", () => {
       const originalLocation = window.location;
-      const iOSLocation = new URL('capacitor://localhost/callback');
-      
+      const iOSLocation = new URL("capacitor://localhost/callback");
+
       delete (window as any).location;
-      Object.defineProperty(window, 'location', {
+      Object.defineProperty(window, "location", {
         value: iOSLocation,
         writable: true,
-        configurable: true
+        configurable: true,
       });
 
       const redirectUri = "https://example.com/callback";
       const searchParams = new URLSearchParams(Object.entries({ code: "123" }));
 
       const result = isRedirectCallback(redirectUri, searchParams);
-      
+
       delete (window as any).location;
-      Object.defineProperty(window, 'location', {
+      Object.defineProperty(window, "location", {
         value: originalLocation,
         writable: true,
-        configurable: true
+        configurable: true,
       });
 
       expect(result).toBe(true);

--- a/src/utils/is-redirect-callback.ts
+++ b/src/utils/is-redirect-callback.ts
@@ -7,5 +7,8 @@ export function isRedirectCallback(
 
   const { pathname: currentPathName } = window.location;
   const redirectPathname = new URL(redirectUri).pathname;
-  return currentPathName === redirectPathname || currentPathName === `${redirectPathname}/`;
+  return (
+    currentPathName === redirectPathname ||
+    currentPathName === `${redirectPathname}/`
+  );
 }

--- a/src/utils/is-redirect-callback.ts
+++ b/src/utils/is-redirect-callback.ts
@@ -5,7 +5,7 @@ export function isRedirectCallback(
   const hasCode = searchParams.has("code");
   if (!hasCode) return false;
 
-  const { protocol, host, pathname } = window.location;
-  const currentUri = `${protocol}//${host}${pathname}`;
-  return currentUri === redirectUri || currentUri === `${redirectUri}/`;
+  const { pathname: currentPathName } = window.location;
+  const redirectPathname = new URL(redirectUri).pathname;
+  return currentPathName === redirectPathname || currentPathName === `${redirectPathname}/`;
 }


### PR DESCRIPTION
## TL;DR

- **Problem 1**: `signIn()`, `signUp()`, and default `signOut()` broke in WebViews by opening URLs in the external browser.
**Solution 1**: Added `getSignInUrl()`, `getSignUpUrl()` to get URLs without auto-redirect and a `noRedirect` option for `signOut()`.

- **Problem 2**: `isRedirectCallback()` failed in WebViews due to different URL schemes.
**Solution 2**: Now `isRedirectCallback()` only compares the URL path, ignoring the scheme.

- **Impact**: authkit-js is now compatible with hybrid mobile apps without breaking navigation. Tests added and an existing test fixed.

## Overview

This pull request introduces two key fixes to enable authkit-js to work properly in mobile app WebViews (Android and iOS):

1. **The use of window.location.assign() breaks the mobile app authentication flow** 

   -> Added new methods to obtain auth URLs without automatic navigation

1. **isRedirectCallback does not work with WebViews URL schemes** 

   -> Modified the URL comparison to focus on pathname instead of the full URL

## Issue 1: window.location.assign()

When using authkit-js in a WebView within an Android or iOS application, using the `signIn()`, `signUp()` and `signOut()` methods breaks the authentication flow.  This is due to the default behavior of `window.location.assign()` in a WebView, which opens the URL in the default web browsing app. As a consequence the user leaves the hybrid app where authkit-js is used. 

As a mobile app developer, I need to be able to open the `signIn` or `signUp` URLs in an in-app browser, so the user does not leave the app during the authentication flow. Also, I need to be able to call `signOut()` without leaving the app. 

### Changes:

1. Added two new public methods to get authentication URLs without automatic navigation:

   - `getSignInUrl()` - Returns the sign-in URL without navigation
   - `getSignUpUrl()` - Returns the sign-up URL without navigation

1. Added a `noRedirect` option to `signOut()` method that makes a call to the logout URL without navigating away from the app : 

   ```javascript
   signOut({ noRedirect: true });
   ```

1. Refactored the original `signIn()` and `signUp()` methods to use a common internal method `#getAuthorizationUrl()` to generate the authentication URLs

These changes allow mobile applications to:

- Obtain authentication URLs and handle them within the WebView without breaking the app's navigation flow
- Handle logout operations without uncontrolled redirects

## Issue 2: isRedirectCallback logic

The original implementation of `isRedirectCallback()` compared the full current URL against the redirect URI. This doesn't work properly in a mobile apps WebView, where the URL scheme might be different (e.g., `capacitor://localhost` on iOS or `http://localhost` on Android). See [Capacitor documentation about these URL schemes](https://ionicframework.com/docs/troubleshooting/cors).

### Changes:

- Modified `isRedirectCallback()` to only compare URL pathnames rather than the full URL.

- Added tests to verify the new pathname-based comparison works correctly.

This change allows the library to correctly identify redirect callbacks regardless of the URL scheme (http, https, capacitor, etc.), making it compatible with hybrid mobile apps running in WebViews.

## Testing

The changes have been thoroughly tested with:

- Unit tests for the new methods and modified logic
- Tests for the `noRedirect` option in the sign-out flow

While implementing the tests, I found out one of the `isRedirectCallback()` tests was not testing its intended functionality. This PR also addresses this issue. 

## Impact

These changes maintain backward compatibility while enabling authkit-js to be used in hybrid mobile applications.