### PR TITLE
Add forceRefresh option to `getAccessToken` method

### DIFF
--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -140,8 +140,8 @@ export class Client {
     }
   }
 
-  async getAccessToken(): Promise<string> {
-    if (this.#shouldRefresh()) {
+  async getAccessToken(options?: { forceRefresh?: boolean }): Promise<string> {
+    if (options?.forceRefresh || this.#shouldRefresh()) {
       try {
         await this.#refreshSession();
       } catch (err) {


### PR DESCRIPTION
This pull request introduces a new feature to allow forced refresh of access tokens in the `Client` class and adds corresponding test coverage. The most important changes include updating the `getAccessToken` method to support a `forceRefresh` option and adding a test case to verify this behavior.

### New Feature: Forced Refresh of Access Tokens
* [`src/create-client.ts`](diffhunk://#diff-781608bae5ee50dc3205452ef8edee06506f484c4cdab631c0494c7abb6771beL143-R144): Updated the `getAccessToken` method in the `Client` class to accept an optional `forceRefresh` parameter. When `forceRefresh` is true, the access token is refreshed regardless of its expiration status.

### Test Coverage
* [`src/create-client.test.ts`](diffhunk://#diff-0e70951cb32ea9343aa70d26ce568a18783c6bf923d5dcfd2b3a240ac3bc0e42R525-R556): Added a new test case to ensure the `getAccessToken` method correctly refreshes the access token when `forceRefresh` is set to true. The test verifies that the refreshed token has the expected claims.