### PR TITLE
Add support for custom claims in `getClaims` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 export { createClient } from "./create-client";
 export { getClaims } from "./utils/session-data";
-export { User, AuthenticationResponse, OnRefreshResponse } from "./interfaces";
+export {
+  User,
+  AuthenticationResponse,
+  OnRefreshResponse,
+  JwtHeader,
+  JwtPayload,
+} from "./interfaces";
 export { AuthKitError, LoginRequiredError } from "./errors";

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -7,3 +7,4 @@ export type { CreateClientOptions } from "./create-client-options.interface";
 export type { GetAuthorizationUrlOptions } from "./get-authorization-url-options.interface";
 export type { Impersonator, ImpersonatorRaw } from "./impersonator.interface";
 export type { User, UserRaw } from "./user.interface";
+export type { JwtHeader, JwtPayload } from "./jwt.interface";

--- a/src/interfaces/jwt.interface.ts
+++ b/src/interfaces/jwt.interface.ts
@@ -1,0 +1,64 @@
+/**
+ * JWT (JSON Web Token) Interface Definitions
+ */
+export interface JwtHeader {
+  alg: string;
+  typ?: string | undefined;
+  cty?: string | undefined;
+  crit?: Array<string | Exclude<keyof JwtHeader, "crit">> | undefined;
+  kid?: string | undefined;
+  jku?: string | undefined;
+  x5u?: string | string[] | undefined;
+  "x5t#S256"?: string | undefined;
+  x5t?: string | undefined;
+  x5c?: string | string[] | undefined;
+}
+/**
+ * JWT Payload Interface
+ */
+export interface JwtPayload {
+  /**
+   * Session ID of the JWT, used to identify the session
+   */
+  sid: string;
+
+  /**
+   * Issuer of the JWT
+   */
+  iss: string;
+  /**
+   * Subject of the JWT
+   */
+  sub: string;
+  /**
+   * Audience of the JWT, can be a single string or an array of strings
+   */
+  aud?: string | string[];
+  /**
+   * Expiration time of the JWT, represented as a Unix timestamp
+   */
+  exp: number;
+  /**
+   * Issued at time of the JWT, represented as a Unix timestamp
+   */
+  iat: number;
+  /**
+   * JWT ID, a unique identifier for the JWT
+   */
+  jti: string;
+
+  /**
+   * Organization ID associated with the JWT
+   */
+  org_id?: string;
+
+  /**
+   * Role of the user associated with the JWT
+   */
+  role?: string;
+
+  /**
+   * Permissions granted to the user associated with the JWT
+   */
+  permissions?: string[];
+}

--- a/src/utils/jwt.test.ts
+++ b/src/utils/jwt.test.ts
@@ -1,0 +1,175 @@
+import { decodeJwt } from "./jwt";
+
+describe("decodeJwt", () => {
+  // Valid JWT token for testing (not a real token, just for testing purposes)
+  const validToken =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2Nzg5MCIsImF1ZCI6WyJhdWRpZW5jZTEiLCJhdWRpZW5jZTIiXSwiZXhwIjoxNzM1Njg5NjAwLCJpYXQiOjE3MzU2MDMyMDAsImp0aSI6InVuaXF1ZS1pZCIsImN1c3RvbSI6InZhbHVlIiwibmVzdGVkIjp7ImtleSI6InZhbHVlIn19.signature";
+
+  describe("valid JWT tokens", () => {
+    it("should decode a valid JWT token", () => {
+      const result = decodeJwt(validToken);
+
+      expect(result.header).toEqual({
+        alg: "HS256",
+        typ: "JWT",
+        kid: "test-key",
+      });
+
+      expect(result.payload).toEqual({
+        iss: "https://example.com",
+        sub: "1234567890",
+        aud: ["audience1", "audience2"],
+        exp: 1735689600,
+        iat: 1735603200,
+        jti: "unique-id",
+        custom: "value",
+        nested: { key: "value" },
+      });
+    });
+
+    it("should decode a JWT with minimal header", () => {
+      const minimalToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature";
+      const result = decodeJwt(minimalToken);
+
+      expect(result.header).toEqual({
+        alg: "HS256",
+      });
+
+      expect(result.payload).toEqual({
+        sub: "123",
+      });
+    });
+
+    it("should decode a JWT with custom payload type", () => {
+      interface CustomPayload {
+        customField: string;
+        customNumber: number;
+      }
+
+      const customToken =
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMiLCJjdXN0b21GaWVsZCI6InRlc3QiLCJjdXN0b21OdW1iZXIiOjQyfQ.signature";
+      const result = decodeJwt<CustomPayload>(customToken);
+
+      expect(result.payload.customField).toBe("test");
+      expect(result.payload.customNumber).toBe(42);
+      expect(result.payload.sub).toBe("123");
+    });
+
+    it("should handle JWT with array audience", () => {
+      const result = decodeJwt(validToken);
+      expect(result.payload.aud).toEqual(["audience1", "audience2"]);
+    });
+
+    it("should handle JWT with string audience", () => {
+      const singleAudToken =
+        "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJzaW5nbGUtYXVkaWVuY2UifQ.signature";
+      const result = decodeJwt(singleAudToken);
+      expect(result.payload.aud).toBe("single-audience");
+    });
+  });
+
+  describe("invalid JWT tokens", () => {
+    it("should throw error for JWT with less than 3 parts", () => {
+      expect(() => decodeJwt("invalid.token")).toThrow("Invalid JWT format");
+      expect(() => decodeJwt("invalid")).toThrow("Invalid JWT format");
+    });
+
+    it("should throw error for JWT with more than 3 parts", () => {
+      expect(() => decodeJwt("too.many.parts.here")).toThrow(
+        "Invalid JWT format",
+      );
+    });
+
+    it("should throw error for empty string", () => {
+      expect(() => decodeJwt("")).toThrow("Invalid JWT format");
+    });
+
+    it("should throw error for invalid base64 in header", () => {
+      const invalidHeaderToken = "invalid!base64.eyJzdWIiOiIxMjMifQ.signature";
+      expect(() => decodeJwt(invalidHeaderToken)).toThrow(
+        "Failed to decode JWT",
+      );
+    });
+
+    it("should throw error for invalid base64 in payload", () => {
+      const invalidPayloadToken =
+        "eyJhbGciOiJIUzI1NiJ9.invalid!base64.signature";
+      expect(() => decodeJwt(invalidPayloadToken)).toThrow(
+        "Failed to decode JWT",
+      );
+    });
+
+    it("should throw error for non-JSON header", () => {
+      // "not json" in base64url
+      const nonJsonHeaderToken = "bm90IGpzb24.eyJzdWIiOiIxMjMifQ.signature";
+      expect(() => decodeJwt(nonJsonHeaderToken)).toThrow(
+        "Failed to decode JWT",
+      );
+    });
+
+    it("should throw error for non-JSON payload", () => {
+      // "not json" in base64url
+      const nonJsonPayloadToken = "eyJhbGciOiJIUzI1NiJ9.bm90IGpzb24.signature";
+      expect(() => decodeJwt(nonJsonPayloadToken)).toThrow(
+        "Failed to decode JWT",
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty header object", () => {
+      const emptyHeaderToken = "e30.eyJzdWIiOiIxMjMifQ.signature";
+      const result = decodeJwt(emptyHeaderToken);
+      expect(result.header).toEqual({});
+    });
+
+    it("should handle empty payload object", () => {
+      const emptyPayloadToken = "eyJhbGciOiJIUzI1NiJ9.e30.signature";
+      const result = decodeJwt(emptyPayloadToken);
+      expect(result.payload).toEqual({});
+    });
+
+    it("should handle JWT with null values", () => {
+      const nullValueToken =
+        "eyJhbGciOm51bGx9.eyJzdWIiOm51bGwsImRhdGEiOm51bGx9.signature";
+      const result = decodeJwt(nullValueToken);
+      expect(result.header.alg).toBeNull();
+      expect(result.payload.sub).toBeNull();
+    });
+
+    it("should handle JWT with nested objects", () => {
+      const nestedToken =
+        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7Im5lc3RlZCI6eyJkZWVwIjoidmFsdWUifX19.signature";
+      const result = decodeJwt(nestedToken);
+      expect(result.payload).toEqual({
+        data: {
+          nested: {
+            deep: "value",
+          },
+        },
+      });
+    });
+
+    it("should handle JWT with arrays in payload", () => {
+      const arrayToken =
+        "eyJhbGciOiJIUzI1NiJ9.eyJyb2xlcyI6WyJhZG1pbiIsInVzZXIiXSwic2NvcGVzIjpbInJlYWQiLCJ3cml0ZSJdfQ.signature";
+      const result = decodeJwt(arrayToken);
+      expect(result.payload).toEqual({
+        roles: ["admin", "user"],
+        scopes: ["read", "write"],
+      });
+    });
+
+    it("should handle JWT with numeric values", () => {
+      const numericToken =
+        "eyJhbGciOiJIUzI1NiJ9.eyJjb3VudCI6NDIsInJhdGlvIjozLjE0LCJhY3RpdmUiOnRydWV9.signature";
+      const result = decodeJwt(numericToken);
+      expect(result.payload).toEqual({
+        count: 42,
+        ratio: 3.14,
+        active: true,
+      });
+    });
+  });
+});
+

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,43 @@
+import { JwtHeader, JwtPayload } from "../interfaces/jwt.interface";
+
+/**
+ * Decodes a base64url encoded string
+ * @param input The base64url string to decode
+ * @returns The decoded string
+ */
+function decodeBase64Url(input: string): string {
+  const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  return atob(base64 + padding);
+}
+
+/**
+ * Decodes a JWT token and returns its header and payload
+ * @param token The JWT token to decode
+ * @return An object containing the decoded header and payload
+ * @throws Error if the token is not in a valid JWT format or if decoding fails
+ */
+// should replace this with jose if we ever need to verify the JWT
+export function decodeJwt<T = {}>(
+  token: string,
+): {
+  header: JwtHeader;
+  payload: JwtPayload & T;
+} {
+  const parts = token.split(".");
+
+  if (parts.length !== 3) {
+    throw new Error("Invalid JWT format");
+  }
+
+  try {
+    const header = JSON.parse(decodeBase64Url(parts[0])) as JwtHeader;
+    const payload = JSON.parse(decodeBase64Url(parts[1])) as JwtPayload & T;
+
+    return { header, payload };
+  } catch (error) {
+    throw new Error(
+      `Failed to decode JWT: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/utils/session-data.ts
+++ b/src/utils/session-data.ts
@@ -1,22 +1,15 @@
-import { AuthenticationResponse } from "../interfaces";
+import { AuthenticationResponse, JwtPayload } from "../interfaces";
+import { decodeJwt } from "./jwt";
 import { memoryStorage } from "./memory-storage";
 import { storageKeys } from "./storage-keys";
 
-interface AccessToken {
-  exp: number;
-  iat: number;
-  iss: string;
-  jti: string;
-  sid: string;
-  sub: string;
-  org_id?: string;
-  role?: string;
-  permissions?: string[];
-}
-
-// should replace this with jose if we ever need to verify the JWT
-export function getClaims(accessToken: string) {
-  return JSON.parse(atob(accessToken.split(".")[1])) as AccessToken;
+/**
+ * Retrieves the claims from a JWT access token.
+ * @param accessToken - The JWT access token to decode.
+ * @returns The decoded JWT payload, which includes the claims.
+ */
+export function getClaims<T = {}>(accessToken: string): JwtPayload & T {
+  return decodeJwt<T>(accessToken).payload;
 }
 
 export function setSessionData(


### PR DESCRIPTION
This pull request introduces enhancements to JWT handling and testing, with significant updates to the `decodeJwt` function, JWT interfaces, and related utilities. It also refines test cases and improves the overall structure for better maintainability and clarity.

### JWT Handling Enhancements:

* **Added `decodeJwt` utility function**: Introduced a new function to decode JWT tokens, returning both the header and payload. This replaces the previous manual decoding approach and improves error handling. (`src/utils/jwt.ts`, [src/utils/jwt.tsR1-R43](diffhunk://#diff-bc3253061283423c721c833f262624f2ba8b6073381c5122cc6671b500cfc743R1-R43))
* **Updated `getClaims` function**: Refactored the function to use `decodeJwt` instead of manual base64 decoding, simplifying the code and ensuring consistency. (`src/utils/session-data.ts`, [src/utils/session-data.tsL1-R12](diffhunk://#diff-95010fb015f6a0a08b6806392bc2d993462171b43d91c15d4c7ef716710b511bL1-R12))

### Interface Improvements:

* **Defined `JwtHeader` and `JwtPayload` interfaces**: Added detailed type definitions for JWT headers and payloads, improving type safety and documentation. (`src/interfaces/jwt.interface.ts`, [src/interfaces/jwt.interface.tsR1-R64](diffhunk://#diff-80a14d5e1a5cd2f45d3b4328fe2c2cc676665a099d68a154c39d729a84fed34dR1-R64))
* **Exported new JWT interfaces**: Updated exports to include `JwtHeader` and `JwtPayload` for external use. (`src/index.ts`, [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L3-R9); `src/interfaces/index.ts`, [[2]](diffhunk://#diff-2433a58dd5b382f3ef0faf44d5ab97bf79428a0a1452d72934c9ca3c77a237bcR10)

### Test Coverage Enhancements:

* **Expanded JWT test cases**: Added comprehensive test cases for `decodeJwt`, covering valid tokens, invalid formats, edge cases, and nested structures. (`src/utils/jwt.test.ts`, [src/utils/jwt.test.tsR1-R175](diffhunk://#diff-31dc9de163d99e6f7bdb07ee8ce38416c94089120befeae525eab787b743847bR1-R175))
* **Refined `create-client` tests**: Adjusted test expectations to match the updated JWT handling, ensuring compatibility with the new `decodeJwt` logic. (`src/create-client.test.ts`, [[1]](diffhunk://#diff-0e70951cb32ea9343aa70d26ce568a18783c6bf923d5dcfd2b3a240ac3bc0e42R49-R63) [[2]](diffhunk://#diff-0e70951cb32ea9343aa70d26ce568a18783c6bf923d5dcfd2b3a240ac3bc0e42L674-R680) [[3]](diffhunk://#diff-0e70951cb32ea9343aa70d26ce568a18783c6bf923d5dcfd2b3a240ac3bc0e42L693-R699) [[4]](diffhunk://#diff-0e70951cb32ea9343aa70d26ce568a18783c6bf923d5dcfd2b3a240ac3bc0e42L882-R888)