### PR TITLE
Add `feature_flags` claim on jwt interface

### DIFF
--- a/src/interfaces/jwt.interface.ts
+++ b/src/interfaces/jwt.interface.ts
@@ -61,4 +61,9 @@ export interface JWTPayload {
    * Permissions granted to the user associated with the JWT
    */
   permissions?: string[];
+
+  /**
+   * Feature flags granted to the organization associated with the JWT
+   */
+  feature_flags?: string[];
 }


### PR DESCRIPTION
Add `feature_flags` claim on jwt interface. This change will be used in `authkit-react` to add support for the `feature_flags` JWT claim in https://github.com/workos/authkit-react/pull/65