### PR TITLE
Stop unnecessarily setting screen_hint=sign-in

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -257,7 +257,7 @@ describe("create-client", () => {
         restoreLocation();
       });
 
-      it("generates a PKCE challenge and redirects to the AuthKit sign-in page", async () => {
+      it("generates a PKCE challenge and redirects to AuthKit", async () => {
         const { scope } = nockRefresh();
         expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeNull();
 
@@ -282,7 +282,6 @@ describe("create-client", () => {
             provider: "authkit",
             redirect_uri: "https://example.com/",
             response_type: "code",
-            screen_hint: "sign-in",
           },
         });
         expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeDefined();
@@ -341,7 +340,7 @@ describe("create-client", () => {
         restoreLocation();
       });
 
-      it("generates a PKCE challenge and returns the AuthKit sign-in page URL", async () => {
+      it("generates a PKCE challenge and returns the AuthKit URL", async () => {
         const { scope } = nockRefresh();
         expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeNull();
 
@@ -368,7 +367,6 @@ describe("create-client", () => {
             provider: "authkit",
             redirect_uri: "https://example.com/",
             response_type: "code",
-            screen_hint: "sign-in",
           },
         });
         expect(sessionStorage.getItem(storageKeys.codeVerifier)).toBeDefined();

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -30,7 +30,7 @@ interface RedirectOptions {
   organizationId?: string;
   passwordResetToken?: string;
   state?: any;
-  type: "sign-in" | "sign-up";
+  screenHint?: "sign-in" | "sign-up";
 }
 
 type State =
@@ -116,23 +116,29 @@ export class Client {
     }
   }
 
-  async getSignInUrl(opts: Omit<RedirectOptions, "type"> = {}) {
-    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-in" });
+  async getSignInUrl(opts: Omit<RedirectOptions, "screenHint"> = {}) {
+    const url = await this.#getAuthorizationUrl({ ...opts });
     return url;
   }
 
-  async getSignUpUrl(opts: Omit<RedirectOptions, "type"> = {}) {
-    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-up" });
+  async getSignUpUrl(opts: Omit<RedirectOptions, "screenHint"> = {}) {
+    const url = await this.#getAuthorizationUrl({
+      ...opts,
+      screenHint: "sign-up",
+    });
     return url;
   }
 
-  async signIn(opts: Omit<RedirectOptions, "type"> = {}) {
-    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-in" });
+  async signIn(opts: Omit<RedirectOptions, "screenHint"> = {}) {
+    const url = await this.#getAuthorizationUrl({ ...opts });
     window.location.assign(url);
   }
 
-  async signUp(opts: Omit<RedirectOptions, "type"> = {}) {
-    const url = await this.#getAuthorizationUrl({ ...opts, type: "sign-up" });
+  async signUp(opts: Omit<RedirectOptions, "screenHint"> = {}) {
+    const url = await this.#getAuthorizationUrl({
+      ...opts,
+      screenHint: "sign-up",
+    });
     window.location.assign(url);
   }
 
@@ -433,7 +439,7 @@ An authorization_code was supplied for a login which did not originate at the ap
     organizationId,
     passwordResetToken,
     state,
-    type,
+    screenHint,
   }: RedirectOptions) {
     const { codeVerifier, codeChallenge } = await createPkceChallenge();
     // store the code verifier in session storage for later use (after the redirect back from authkit)
@@ -447,7 +453,7 @@ An authorization_code was supplied for a login which did not originate at the ap
       organizationId,
       passwordResetToken,
       redirectUri: this.#redirectUri,
-      screenHint: type,
+      screenHint,
       state: state ? JSON.stringify(state) : undefined,
     });
 


### PR DESCRIPTION
It's counter-productive to send this parameter because it prevents us from contextually redirecting user's back to the sign-up page when clients aren't behaving properly.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
