### PR TITLE
feat: support multi-app cookies and scoped storage keys

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,9 @@ permissions:
   pull-requests: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ vars.SDK_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Bump `actions/create-github-app-token` from v2.2.2 to v3.0.0 (Node.js 24 native support)
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var for `release-please-action` v4.4.0
- Add empty conventional commit to trigger release-please for unreleased features (multi-app cookies, scoped storage keys)

## Context
The release-please workflow wasn't creating a release PR because two feature commits (`5446386`, `367e4c5`) didn't use Conventional Commits format and were silently skipped. The empty `feat:` commit ensures release-please picks them up on merge.