### PR TITLE
fix: catch lock timeout errors instead of leaking to app

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -258,9 +258,7 @@ describe("create-client", () => {
       Object.defineProperty(navigator, "locks", {
         value: {
           request: () =>
-            Promise.reject(
-              new DOMException("Signal timed out.", "AbortError"),
-            ),
+            Promise.reject(new DOMException("Signal timed out.", "AbortError")),
         },
         configurable: true,
       });

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -12,8 +12,6 @@ import {
 import { mockLocation, restoreLocation } from "./testing/mock-location";
 import { getClaims } from "./utils/session-data";
 import { storageKeys } from "./utils/storage-keys";
-import { LockError } from "./utils/locking";
-import { MockWebLocks } from "./testing/mock-web-locks";
 import nock from "nock";
 
 describe("create-client", () => {
@@ -42,8 +40,7 @@ describe("create-client", () => {
       "https://example.com/callback?code=code_123",
     );
 
-    // @ts-ignore — clean up any navigator.locks mock
-    delete navigator.locks;
+    delete (navigator as any).locks;
 
     nock.cleanAll();
   });
@@ -255,6 +252,18 @@ describe("create-client", () => {
         });
 
       return { scope };
+    }
+
+    function installLockTimeout() {
+      Object.defineProperty(navigator, "locks", {
+        value: {
+          request: () =>
+            Promise.reject(
+              new DOMException("Signal timed out.", "AbortError"),
+            ),
+        },
+        configurable: true,
+      });
     }
 
     describe("signIn", () => {
@@ -946,18 +955,6 @@ describe("create-client", () => {
           scope.done();
         });
 
-        const installLockTimeout = () => {
-          Object.defineProperty(navigator, "locks", {
-            value: {
-              request: () =>
-                Promise.reject(
-                  new DOMException("Signal timed out.", "AbortError"),
-                ),
-            },
-            configurable: true,
-          });
-        };
-
         it("returns the existing token when lock times out and token is unexpired", async () => {
           const now = Date.now();
           const { scope } = nockRefresh({
@@ -1107,15 +1104,7 @@ describe("create-client", () => {
         });
         createClientScope.done();
 
-        Object.defineProperty(navigator, "locks", {
-          value: {
-            request: () =>
-              Promise.reject(
-                new DOMException("Signal timed out.", "AbortError"),
-              ),
-          },
-          configurable: true,
-        });
+        installLockTimeout();
 
         await expect(
           client.switchToOrganization({ organizationId: "org_123abc" }),

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -3,10 +3,17 @@
  */
 
 import { createClient } from "./create-client";
-import { LoginRequiredError, NoSessionError, RefreshError } from "./errors";
+import {
+  LoginRequiredError,
+  NoSessionError,
+  RefreshError,
+  RefreshTimeoutError,
+} from "./errors";
 import { mockLocation, restoreLocation } from "./testing/mock-location";
 import { getClaims } from "./utils/session-data";
 import { storageKeys } from "./utils/storage-keys";
+import { LockError } from "./utils/locking";
+import { MockWebLocks } from "./testing/mock-web-locks";
 import nock from "nock";
 
 describe("create-client", () => {
@@ -34,6 +41,9 @@ describe("create-client", () => {
       "",
       "https://example.com/callback?code=code_123",
     );
+
+    // @ts-ignore — clean up any navigator.locks mock
+    delete navigator.locks;
 
     nock.cleanAll();
   });
@@ -936,6 +946,73 @@ describe("create-client", () => {
           scope.done();
         });
 
+        const installLockTimeout = () => {
+          Object.defineProperty(navigator, "locks", {
+            value: {
+              request: () =>
+                Promise.reject(
+                  new DOMException("Signal timed out.", "AbortError"),
+                ),
+            },
+            configurable: true,
+          });
+        };
+
+        it("returns the existing token when lock times out and token is unexpired", async () => {
+          const now = Date.now();
+          const { scope } = nockRefresh({
+            accessTokenClaims: {
+              iat: now,
+              exp: now + 60,
+            },
+          });
+
+          client = await createClient("client_123abc", {
+            redirectUri: "https://example.com/",
+            onBeforeAutoRefresh: () => false,
+            refreshBufferInterval: 120,
+          });
+          scope.done();
+
+          installLockTimeout();
+
+          const accessToken = await client.getAccessToken();
+          expect(accessToken).toMatch(/^eyJ/);
+        });
+
+        it("throws RefreshTimeoutError when lock times out and token is expired", async () => {
+          const client = await clientWithExpiredAccessToken();
+
+          installLockTimeout();
+
+          await expect(client.getAccessToken()).rejects.toThrow(
+            RefreshTimeoutError,
+          );
+        });
+
+        it("throws RefreshTimeoutError on forceRefresh even with unexpired token", async () => {
+          const now = Date.now();
+          const { scope } = nockRefresh({
+            accessTokenClaims: {
+              iat: now,
+              exp: now + 60,
+            },
+          });
+
+          client = await createClient("client_123abc", {
+            redirectUri: "https://example.com/",
+            onBeforeAutoRefresh: () => false,
+            refreshBufferInterval: 120,
+          });
+          scope.done();
+
+          installLockTimeout();
+
+          await expect(
+            client.getAccessToken({ forceRefresh: true }),
+          ).rejects.toThrow(RefreshTimeoutError);
+        });
+
         it("throws an error if the fetch fails", async () => {
           const consoleDebugSpy = jest
             .spyOn(console, "debug")
@@ -1019,6 +1096,36 @@ describe("create-client", () => {
           organizationId: "org_123abc",
           state: { returnTo: "/somewhere" },
         });
+      });
+
+      it("does not throw when lock acquisition times out", async () => {
+        const consoleWarnSpy = jest
+          .spyOn(console, "warn")
+          .mockImplementation();
+        const { scope: createClientScope } = nockRefresh();
+        client = await createClient("client_123abc", {
+          redirectUri: "https://example.com/",
+          onBeforeAutoRefresh: () => false,
+        });
+        createClientScope.done();
+
+        Object.defineProperty(navigator, "locks", {
+          value: {
+            request: () =>
+              Promise.reject(
+                new DOMException("Signal timed out.", "AbortError"),
+              ),
+          },
+          configurable: true,
+        });
+
+        await expect(
+          client.switchToOrganization({ organizationId: "org_123abc" }),
+        ).resolves.toBeUndefined();
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "Couldn't switch organization: lock acquisition timed out.",
+        );
       });
     });
   });

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -975,7 +975,7 @@ describe("create-client", () => {
           expect(accessToken).toMatch(/^eyJ/);
         });
 
-        it("throws RefreshTimeoutError when lock times out and token is expired", async () => {
+        it("throws RefreshTimeoutError when lock times out twice and token is expired", async () => {
           const client = await clientWithExpiredAccessToken();
 
           installLockTimeout();
@@ -983,6 +983,32 @@ describe("create-client", () => {
           await expect(client.getAccessToken()).rejects.toThrow(
             RefreshTimeoutError,
           );
+        });
+
+        it("retries and succeeds when lock times out once then resolves", async () => {
+          const client = await clientWithExpiredAccessToken();
+
+          let callCount = 0;
+          Object.defineProperty(navigator, "locks", {
+            value: {
+              request: (_name: string, _opts: any, cb: any) => {
+                callCount++;
+                if (callCount === 1) {
+                  return Promise.reject(
+                    new DOMException("Signal timed out.", "AbortError"),
+                  );
+                }
+                return cb({ name: _name, mode: "exclusive" });
+              },
+            },
+            configurable: true,
+          });
+
+          const { scope } = nockRefresh();
+          const accessToken = await client.getAccessToken();
+          expect(accessToken).toMatch(/^eyJ/);
+          expect(callCount).toBe(2);
+          scope.done();
         });
 
         it("throws RefreshTimeoutError on forceRefresh even with unexpired token", async () => {

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -1099,9 +1099,7 @@ describe("create-client", () => {
       });
 
       it("does not throw when lock acquisition times out", async () => {
-        const consoleWarnSpy = jest
-          .spyOn(console, "warn")
-          .mockImplementation();
+        const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
         const { scope: createClientScope } = nockRefresh();
         client = await createClient("client_123abc", {
           redirectUri: "https://example.com/",

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -15,7 +15,12 @@ import {
 } from "./utils";
 import { getRefreshToken, getClaims } from "./utils/session-data";
 import { RedirectParams } from "./interfaces/create-client-options.interface";
-import { LoginRequiredError, NoSessionError, RefreshError } from "./errors";
+import {
+  LoginRequiredError,
+  NoSessionError,
+  RefreshError,
+  RefreshTimeoutError,
+} from "./errors";
 import { withLock, LockError } from "./utils/locking";
 import { HttpClient } from "./http-client";
 
@@ -211,7 +216,13 @@ export class Client {
       try {
         await this.#refreshSession();
       } catch (err) {
-        if (err instanceof RefreshError) {
+        if (err instanceof RefreshTimeoutError) {
+          const token = !options?.forceRefresh
+            ? this.#getUnexpiredAccessToken()
+            : undefined;
+          if (token) return token;
+          throw err;
+        } else if (err instanceof RefreshError) {
           throw new LoginRequiredError();
         } else {
           throw err;
@@ -327,7 +338,9 @@ An authorization_code was supplied for a login which did not originate at the ap
     try {
       await this.#refreshSession({ organizationId });
     } catch (error) {
-      if (error instanceof RefreshError) {
+      if (error instanceof RefreshTimeoutError) {
+        console.warn("Couldn't switch organization: lock acquisition timed out.");
+      } else if (error instanceof RefreshError) {
         this.signIn({ ...signInOpts, organizationId });
       } else {
         throw error;
@@ -402,7 +415,7 @@ An authorization_code was supplied for a login which did not originate at the ap
 
         // preserving the original state so that we can try again next time
         this.#state = beginningState;
-        throw error;
+        throw new RefreshTimeoutError(undefined, { cause: error });
       }
 
       if (beginningState.tag !== "INITIAL") {
@@ -488,6 +501,16 @@ An authorization_code was supplied for a login which did not originate at the ap
 
   #getAccessToken() {
     return memoryStorage.getItem(storageKeys.accessToken) as string | undefined;
+  }
+
+  #getUnexpiredAccessToken(): string | undefined {
+    const accessToken = this.#getAccessToken();
+    const expiresAt = memoryStorage.getItem(storageKeys.expiresAt) as
+      | number
+      | undefined;
+    return accessToken && expiresAt && expiresAt > Date.now()
+      ? accessToken
+      : undefined;
   }
 
   get #useCookie() {

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -339,7 +339,9 @@ An authorization_code was supplied for a login which did not originate at the ap
       await this.#refreshSession({ organizationId });
     } catch (error) {
       if (error instanceof RefreshTimeoutError) {
-        console.warn("Couldn't switch organization: lock acquisition timed out.");
+        console.warn(
+          "Couldn't switch organization: lock acquisition timed out.",
+        );
       } else if (error instanceof RefreshError) {
         this.signIn({ ...signInOpts, organizationId });
       } else {

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -221,7 +221,15 @@ export class Client {
             ? this.#getUnexpiredAccessToken()
             : undefined;
           if (token) return token;
-          throw err;
+
+          try {
+            await this.#refreshSession();
+          } catch (retryErr) {
+            if (retryErr instanceof RefreshTimeoutError) throw retryErr;
+            if (retryErr instanceof RefreshError)
+              throw new LoginRequiredError();
+            throw retryErr;
+          }
         } else if (err instanceof RefreshError) {
           throw new LoginRequiredError();
         } else {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,9 +10,8 @@ export class RefreshTimeoutError extends RefreshError {
     message = "Timed out waiting to refresh the session.",
     options?: { cause?: unknown },
   ) {
-    super(message);
+    super(message, options);
     this.name = "RefreshTimeoutError";
-    if (options?.cause) this.cause = options.cause;
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,6 +5,17 @@ export class LoginRequiredError extends AuthKitError {
   readonly message: string = "No access token available";
 }
 
+export class RefreshTimeoutError extends RefreshError {
+  constructor(
+    message = "Timed out waiting to refresh the session.",
+    options?: { cause?: unknown },
+  ) {
+    super(message);
+    this.name = "RefreshTimeoutError";
+    if (options?.cause) this.cause = options.cause;
+  }
+}
+
 export class NoSessionError extends AuthKitError {
   readonly message =
     "SignOut() called without an active session. Provide a returnTo URL to redirect anyway.";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,9 @@ export {
   OnRefreshResponse,
   JWTPayload,
 } from "./interfaces";
-export { AuthKitError, LoginRequiredError, NoSessionError } from "./errors";
+export {
+  AuthKitError,
+  LoginRequiredError,
+  NoSessionError,
+  RefreshTimeoutError,
+} from "./errors";

--- a/src/utils/locking.ts
+++ b/src/utils/locking.ts
@@ -30,6 +30,7 @@ async function withNativeLock<T>(
   } catch (error) {
     if (error instanceof DOMException) {
       switch (error.name) {
+        case "TimeoutError":
         case "AbortError":
           throw new LockError("AcquisitionTimeoutError", lockName, "Native");
 


### PR DESCRIPTION
## Summary

- After laptop sleep, `AbortSignal.timeout(10s)` on `navigator.locks.request` fires before the browser event loop resumes. The resulting `LockError` was escaping raw to the application because `getAccessToken()` only caught `RefreshError`.
- Adds `RefreshTimeoutError extends RefreshError` — flows through existing catch blocks, distinguishable via `instanceof` for apps that need it.
- When lock times out and the existing token is still valid, returns it instead of throwing. When expired or `forceRefresh: true`, throws `RefreshTimeoutError` (not `LoginRequiredError`, since the session is valid).
- Fixes the same bug in `switchToOrganization()` — catches the timeout and warns instead of crashing.
- Defensively catches both `AbortError` and `TimeoutError` DOMException names in `withNativeLock`.

Fixes the issue reported by VectorShift (same family as the Coast investigation from Oct 2024).

## Test plan

- [x] `getAccessToken()` returns existing token when lock times out and token is unexpired
- [x] `getAccessToken()` throws `RefreshTimeoutError` when lock times out and token is expired
- [x] `getAccessToken({ forceRefresh: true })` throws `RefreshTimeoutError` even with unexpired token
- [x] `switchToOrganization()` does not throw raw `LockError` — warns and resolves
- [x] All 82 existing tests pass (no regressions)
- [x] Type check clean (`tsc --noEmit`)
- [x] Build clean (`tsup`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/authkit-js/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->