### PR TITLE
fix: add fetch timeout to prevent indefinite hangs

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -133,6 +133,36 @@ describe("create-client", () => {
 
           nockScope.done();
         });
+
+        it("does not hang when the API is unreachable and the fetch times out", async () => {
+          const originalFetch = global.fetch;
+          const timeoutError = new DOMException(
+            "The operation timed out.",
+            "TimeoutError",
+          );
+          const mockFetch = jest.fn().mockRejectedValue(timeoutError);
+          global.fetch = mockFetch;
+
+          try {
+            client = await createClient("client_123abc", {
+              devMode: false,
+              redirectUri: "https://example.com/",
+            });
+
+            // initialize() has a catch-all around #refreshSession, so
+            // createClient should resolve even though the fetch failed
+            // (rather than hanging forever, as it would with no timeout).
+            expect(client).toBeDefined();
+            expect(client.getUser()).toBeNull();
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+
+            // verify the request had an AbortSignal attached for the timeout
+            const fetchOptions = mockFetch.mock.calls[0][1];
+            expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+          } finally {
+            global.fetch = originalFetch;
+          }
+        });
       });
 
       describe("when devMode is true", () => {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -97,6 +97,7 @@ export class HttpClient {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds `AbortSignal.timeout(30_000)` to the HTTP client's `#post` method
- Without this, a misconfigured or unreachable custom auth domain (e.g., after environment promotion before Cloudflare bootstrapping completes) causes `fetch()` to block indefinitely — `initialize()` never resolves and the React provider's `isLoading` stays `true` forever
- 30 seconds is generous enough for post-sleep/high-latency scenarios but prevents infinite hangs

Surfaced by VectorShift after promoting their staging environment to production — `identity.vectorshift.ai` wasn't routing correctly and `fetch` hung with no timeout.

Related: #117 (post-sleep lock timeout), workos/authkit-react (createClient rejection handling PR)

## Test plan

- [x] All 83 tests pass (`npm test`)
- [x] New test: `createClient` resolves (not hangs) when fetch rejects with a `TimeoutError`
- [x] `npm run build` passes
- [ ] Verify in a browser: when `apiHostname` points to an unreachable domain, initialization times out after ~30s instead of hanging forever