### PR TITLE
fix: Only clear `code` and `state`

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -109,6 +109,34 @@ describe("create-client", () => {
           expect(location.search).toBe("");
           nockScope.done();
         });
+
+        it("preserves non-OAuth query params when clearing the URL", async () => {
+          history.replaceState(
+            null,
+            "",
+            "https://example.com/callback?code=code_123&state=%7B%7D&foo=bar&baz=qux",
+          );
+          sessionStorage.setItem(storageKeys.codeVerifier, "code_verifier");
+          const nockScope = nock("https://api.workos.com")
+            .post("/user_management/authenticate", {
+              code: "code_123",
+              client_id: "client_123abc",
+              grant_type: "authorization_code",
+              code_verifier: "code_verifier",
+            })
+            .reply(200, {
+              user: {},
+              access_token: mockAccessToken(),
+              refresh_token: "refresh_token",
+            });
+
+          client = await createClient("client_123abc", {
+            redirectUri: "https://example.com/callback",
+          });
+
+          expect(location.search).toBe("?foo=bar&baz=qux");
+          nockScope.done();
+        });
       });
     });
 

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -290,9 +290,10 @@ An authorization_code was supplied for a login which did not originate at the ap
       }
     }
 
-    // Remove code from search params
+    // Remove code/state from search params
     const cleanUrl = new URL(window.location.toString());
-    cleanUrl.search = "";
+    cleanUrl.searchParams.delete("code");
+    cleanUrl.searchParams.delete("state");
     window.sessionStorage.removeItem(storageKeys.codeVerifier);
     window.history.replaceState({}, "", cleanUrl);
   }


### PR DESCRIPTION
We were rudely clearing all searchParams out of the callback URL instead of just the ones we send.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
