### PR TITLE
fix: Preserve session on transient refresh failures

### DIFF
--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -1097,6 +1097,38 @@ describe("create-client", () => {
           expect(accessToken).toMatch(/^eyJ/);
         });
 
+        it("returns the existing token when a proactive refresh hits a transient failure and token is unexpired", async () => {
+          const now = Date.now();
+          const { scope } = nockRefresh({
+            accessTokenClaims: {
+              iat: now,
+              exp: now + 60,
+            },
+          });
+
+          client = await createClient("client_123abc", {
+            redirectUri: "https://example.com/",
+            onBeforeAutoRefresh: () => false,
+            refreshBufferInterval: 120,
+          });
+          scope.done();
+
+          const transientScope = nock("https://api.workos.com")
+            .post("/user_management/authenticate", {
+              client_id: "client_123abc",
+              grant_type: "refresh_token",
+            })
+            .reply(503, {
+              error: "too_many_requests",
+              error_description: "Could not process refresh token.",
+            });
+
+          const accessToken = await client.getAccessToken();
+          expect(accessToken).toMatch(/^eyJ/);
+
+          transientScope.done();
+        });
+
         it("throws RefreshTimeoutError when lock times out twice and token is expired", async () => {
           const client = await clientWithExpiredAccessToken();
 

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -1017,6 +1017,64 @@ describe("create-client", () => {
           scope.done();
         });
 
+        it.each([
+          ["a rate limit", 429],
+          ["a server error", 500],
+          ["a service unavailable", 503],
+          ["a gateway timeout", 504],
+          ["a request timeout", 408],
+        ])(
+          "preserves the session on a transient refresh failure: %s (%i)",
+          async (_label, status) => {
+            const consoleDebugSpy = jest
+              .spyOn(console, "debug")
+              .mockImplementation();
+            const onRefreshFailure = jest.fn();
+            const now = Date.now();
+            const { scope: initialRefreshScope } = nockRefresh({
+              accessTokenClaims: {
+                iat: now,
+                exp: now,
+                jti: "initial-access-token",
+              },
+            });
+            client = await createClient("client_123abc", {
+              redirectUri: "https://example.com/",
+              onBeforeAutoRefresh: () => false,
+              onRefreshFailure,
+            });
+            initialRefreshScope.done();
+            sessionStorage.setItem("workos-org-id:client_123abc", "org_123abc");
+
+            const scope = nock("https://api.workos.com")
+              .post("/user_management/authenticate", {
+                client_id: "client_123abc",
+                grant_type: "refresh_token",
+              })
+              .reply(status, {
+                error: "too_many_requests",
+                error_description: "Could not process refresh token.",
+              });
+
+            // A transient failure surfaces the RefreshError (not a
+            // LoginRequiredError) so the caller can retry.
+            const error = await client.getAccessToken().catch((e) => e);
+            expect(error).toBeInstanceOf(RefreshError);
+            expect(error).not.toBeInstanceOf(LoginRequiredError);
+            expect(error.isTransient).toBe(true);
+
+            // The session is preserved: storage is untouched and the refresh
+            // failure callback is not fired.
+            expect(sessionStorage.getItem("workos-org-id:client_123abc")).toBe(
+              "org_123abc",
+            );
+            expect(onRefreshFailure).not.toHaveBeenCalled();
+
+            scope.done();
+            consoleDebugSpy.mockRestore();
+          },
+        );
+
         it("returns the existing token when lock times out and token is unexpired", async () => {
           const now = Date.now();
           const { scope } = nockRefresh({

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -1310,6 +1310,38 @@ describe("create-client", () => {
         });
       });
 
+      it("surfaces a transient failure instead of redirecting to sign-in", async () => {
+        const { scope: createClientScope } = nockRefresh();
+        client = await createClient("client_123abc", {
+          redirectUri: "https://example.com/",
+        });
+        createClientScope.done();
+
+        const organizationId = "org_123abc";
+        const switchToOrgScope = nock("https://api.workos.com")
+          .post("/user_management/authenticate", {
+            client_id: "client_123abc",
+            grant_type: "refresh_token",
+            organization_id: organizationId,
+          })
+          .reply(503, {
+            error: "too_many_requests",
+            error_description: "Could not process refresh token.",
+          });
+        const signInSpy = jest.spyOn(client, "signIn").mockImplementation();
+        jest.spyOn(console, "debug").mockImplementation();
+
+        const error = await client
+          .switchToOrganization({ organizationId })
+          .catch((e) => e);
+        switchToOrgScope.done();
+
+        expect(error).toBeInstanceOf(RefreshError);
+        expect(error.isTransient).toBe(true);
+        // The still-valid session is preserved: no forced re-authentication.
+        expect(signInSpy).not.toHaveBeenCalled();
+      });
+
       it("does not throw when lock acquisition times out", async () => {
         const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
         const { scope: createClientScope } = nockRefresh();

--- a/src/create-client.test.ts
+++ b/src/create-client.test.ts
@@ -1129,6 +1129,43 @@ describe("create-client", () => {
           transientScope.done();
         });
 
+        it("starts the background refresh loop when the initial refresh fails transiently", async () => {
+          const consoleDebugSpy = jest
+            .spyOn(console, "debug")
+            .mockImplementation();
+
+          // The initial refresh during initialize() hits a transient 5xx; the
+          // session must be preserved AND the background refresh loop started.
+          const failingScope = nock("https://api.workos.com")
+            .post("/user_management/authenticate", {
+              client_id: "client_123abc",
+              grant_type: "refresh_token",
+            })
+            .reply(503, {
+              error: "too_many_requests",
+              error_description: "Could not process refresh token.",
+            });
+
+          const { scope: recoveryScope } = nockRefresh();
+
+          client = await createClient("client_123abc", {
+            redirectUri: "https://example.com/",
+            onBeforeAutoRefresh: () => true,
+          });
+
+          failingScope.done();
+          // The transient failure left no session yet.
+          expect(client.getUser()).toBeNull();
+
+          // Wait for the 1s heartbeat to fire and recover the session.
+          await new Promise((resolve) => setTimeout(resolve, 1100));
+
+          recoveryScope.done();
+          expect(client.getUser()).toEqual({ id: "user_123abc" });
+
+          consoleDebugSpy.mockRestore();
+        });
+
         it("throws RefreshTimeoutError when lock times out twice and token is expired", async () => {
           const client = await clientWithExpiredAccessToken();
 

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -223,11 +223,18 @@ export class Client {
             await this.#refreshSession();
           } catch (retryErr) {
             if (retryErr instanceof RefreshTimeoutError) throw retryErr;
-            if (retryErr instanceof RefreshError)
+            if (retryErr instanceof RefreshError) {
+              // A transient failure preserves the session; surface it so the
+              // caller can retry rather than forcing re-authentication.
+              if (retryErr.isTransient) throw retryErr;
               throw new LoginRequiredError();
+            }
             throw retryErr;
           }
         } else if (err instanceof RefreshError) {
+          // A transient failure preserves the session; surface it so the caller
+          // can retry rather than forcing re-authentication.
+          if (err.isTransient) throw err;
           throw new LoginRequiredError();
         } else {
           throw err;
@@ -360,6 +367,11 @@ An authorization_code was supplied for a login which did not originate at the ap
           "Couldn't switch organization: lock acquisition timed out.",
         );
       } else if (error instanceof RefreshError) {
+        // A transient failure preserves the session; surface it so the caller
+        // can retry rather than forcing a full re-authentication redirect.
+        if (error.isTransient) {
+          throw error;
+        }
         this.signIn({ ...signInOpts, organizationId });
       } else {
         throw error;
@@ -441,7 +453,7 @@ An authorization_code was supplied for a login which did not originate at the ap
         console.debug(error);
       }
 
-      if (error instanceof RefreshError) {
+      if (error instanceof RefreshError && !error.isTransient) {
         removeSessionData({ devMode: this.#devMode, clientId: this.#clientId });
         sessionStorage.removeItem(orgIdKey(this.#clientId));
         sessionStorage.removeItem(LEGACY_ORG_ID_KEY);
@@ -454,8 +466,10 @@ An authorization_code was supplied for a login which did not originate at the ap
 
         this.#state = { tag: "ERROR" };
       } else {
-        // transitioning into the AUTHENTICATED state ensures that we will
-        // attempt to refresh the token on future getAccessToken calls()
+        // A transient failure (network error, timeout, 429, or 5xx) is not a
+        // signal that the refresh token is dead, so preserve the session data.
+        // Transitioning into the AUTHENTICATED state ensures that we will
+        // attempt to refresh the token on future getAccessToken() calls.
         //
         // this could maybe be a new state for clarity? TEMPORARY_ERROR?
         this.#state = { tag: "AUTHENTICATED" };

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -232,9 +232,19 @@ export class Client {
             throw retryErr;
           }
         } else if (err instanceof RefreshError) {
-          // A transient failure preserves the session; surface it so the caller
-          // can retry rather than forcing re-authentication.
-          if (err.isTransient) throw err;
+          // A transient failure preserves the session. If the refresh was
+          // proactive (the token is within the buffer window but not yet
+          // expired) and this isn't a forced refresh, return the still-valid
+          // token so a brief blip doesn't fail a serviceable call. Otherwise
+          // surface the error so the caller can retry rather than being forced
+          // to re-authenticate.
+          if (err.isTransient) {
+            const token = !options?.forceRefresh
+              ? this.#getUnexpiredAccessToken()
+              : undefined;
+            if (token) return token;
+            throw err;
+          }
           throw new LoginRequiredError();
         } else {
           throw err;

--- a/src/create-client.ts
+++ b/src/create-client.ts
@@ -129,8 +129,12 @@ export class Client {
         await this.#refreshSession();
         this.#scheduleAutomaticRefresh();
       } catch {
-        // this is expected to fail if a user doesn't
-        // have a session. do nothing.
+        // A refresh here is expected to fail if the user has no session, in
+        // which case #doRefresh moves to the ERROR state and we do nothing.
+        // For a transient failure (network error, timeout, 429, 5xx) the
+        // session is preserved (state stays AUTHENTICATED), so still start the
+        // background refresh loop to renew the token once the blip clears.
+        this.#scheduleAutomaticRefreshIfAuthenticated();
       }
     }
   }
@@ -340,6 +344,12 @@ An authorization_code was supplied for a login which did not originate at the ap
     cleanUrl.searchParams.delete("state");
     window.sessionStorage.removeItem(storageKeys.codeVerifier);
     window.history.replaceState({}, "", cleanUrl);
+  }
+
+  #scheduleAutomaticRefreshIfAuthenticated() {
+    if (this.#state.tag === "AUTHENTICATED") {
+      this.#scheduleAutomaticRefresh();
+    }
   }
 
   async #scheduleAutomaticRefresh() {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,36 @@
 export class AuthKitError extends Error {}
-export class RefreshError extends AuthKitError {}
+
+export interface RefreshErrorOptions {
+  cause?: unknown;
+  /** HTTP status of the failed refresh response, if the failure was an HTTP error. */
+  status?: number;
+  /** OAuth error code from the response body (e.g. `"invalid_grant"`), if present. */
+  error?: string;
+  /**
+   * Whether the failure is transient (network error, timeout, 429, or 5xx) and
+   * the session should be preserved and retried, rather than terminal (the
+   * refresh token is dead and the user must re-authenticate).
+   */
+  isTransient?: boolean;
+}
+
+export class RefreshError extends AuthKitError {
+  readonly status?: number;
+  readonly error?: string;
+  readonly isTransient: boolean;
+
+  constructor(message?: string, options: RefreshErrorOptions = {}) {
+    super(
+      message,
+      options.cause != null ? { cause: options.cause } : undefined,
+    );
+    this.name = "RefreshError";
+    this.status = options.status;
+    this.error = options.error;
+    this.isTransient = options.isTransient ?? false;
+  }
+}
+
 export class CodeExchangeError extends AuthKitError {}
 export class LoginRequiredError extends AuthKitError {
   readonly message: string = "No access token available";
@@ -10,7 +41,7 @@ export class RefreshTimeoutError extends RefreshError {
     message = "Timed out waiting to refresh the session.",
     options?: { cause?: unknown },
   ) {
-    super(message, options);
+    super(message, { cause: options?.cause, isTransient: true });
     this.name = "RefreshTimeoutError";
   }
 }

--- a/src/http-client.test.ts
+++ b/src/http-client.test.ts
@@ -1,4 +1,6 @@
+import { RefreshError } from "./errors";
 import { HttpClient } from "./http-client";
+import nock from "nock";
 
 describe("HttpClient", () => {
   let httpClient: HttpClient;
@@ -6,6 +8,94 @@ describe("HttpClient", () => {
   beforeEach(() => {
     httpClient = new HttpClient({
       clientId: "123",
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("authenticateWithRefreshToken", () => {
+    const refresh = () =>
+      httpClient.authenticateWithRefreshToken({
+        refreshToken: "refresh_token",
+        useCookie: false,
+      });
+
+    it.each([
+      ["a rate limit", 429, "too_many_requests"],
+      ["a server error", 500, "server_error"],
+      ["a bad gateway", 502, undefined],
+      ["a service unavailable", 503, undefined],
+      ["a gateway timeout", 504, undefined],
+      ["a request timeout", 408, undefined],
+    ])(
+      "throws a transient RefreshError for %s (%i)",
+      async (_label, status, errorCode) => {
+        nock("https://api.workos.com")
+          .post("/user_management/authenticate")
+          .reply(status, {
+            ...(errorCode && { error: errorCode }),
+            error_description: "Could not process refresh token.",
+          });
+
+        await expect(refresh()).rejects.toMatchObject({
+          name: "RefreshError",
+          status,
+          isTransient: true,
+        });
+      },
+    );
+
+    it("throws a transient RefreshError when a 5xx has a non-JSON body", async () => {
+      nock("https://api.workos.com")
+        .post("/user_management/authenticate")
+        .reply(503, "<html>Service Unavailable</html>", {
+          "content-type": "text/html",
+        });
+
+      await expect(refresh()).rejects.toMatchObject({
+        name: "RefreshError",
+        status: 503,
+        isTransient: true,
+      });
+    });
+
+    it("throws a terminal RefreshError for a 400 invalid_grant", async () => {
+      nock("https://api.workos.com")
+        .post("/user_management/authenticate")
+        .reply(400, {
+          error: "invalid_grant",
+          error_description: "Session has already ended.",
+        });
+
+      await expect(refresh()).rejects.toMatchObject({
+        name: "RefreshError",
+        status: 400,
+        error: "invalid_grant",
+        isTransient: false,
+      });
+    });
+
+    it("throws a terminal RefreshError for a 401", async () => {
+      nock("https://api.workos.com")
+        .post("/user_management/authenticate")
+        .reply(401, {});
+
+      const error = await refresh().catch((e) => e);
+      expect(error).toBeInstanceOf(RefreshError);
+      expect(error.isTransient).toBe(false);
+    });
+
+    it("does not wrap a network failure in a RefreshError", async () => {
+      nock("https://api.workos.com")
+        .post("/user_management/authenticate")
+        .replyWithError(new TypeError("fetch failed"));
+
+      // A raw fetch failure propagates unchanged; create-client treats a
+      // non-RefreshError as transient and preserves the session.
+      const error = await refresh().catch((e) => e);
+      expect(error).not.toBeInstanceOf(RefreshError);
     });
   });
 

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -8,6 +8,16 @@ import { toQueryString } from "./utils";
 
 const DEFAULT_HOSTNAME = "api.workos.com";
 
+// HTTP statuses that indicate a transient failure rather than a dead refresh
+// token: request timeouts (408), rate limits (429), and 5xx. On these the
+// session should be preserved and the refresh retried.
+const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
+interface AuthenticationErrorResponse {
+  error?: string;
+  error_description?: string;
+}
+
 export class HttpClient {
   readonly #baseUrl: string;
   readonly #clientId: string;
@@ -51,9 +61,26 @@ export class HttpClient {
     if (response.ok) {
       const data = (await response.json()) as AuthenticationResponseRaw;
       return deserializeAuthenticationResponse(data);
-    } else {
-      const error = (await response.json()) as any;
-      throw new RefreshError(error.error_description);
+    }
+
+    const { status } = response;
+    const body = await this.#parseErrorBody(response);
+    throw new RefreshError(body.error_description, {
+      status,
+      error: body.error,
+      isTransient: RETRYABLE_REFRESH_STATUS_CODES.has(status),
+    });
+  }
+
+  async #parseErrorBody(
+    response: Response,
+  ): Promise<AuthenticationErrorResponse> {
+    try {
+      return (await response.json()) as AuthenticationErrorResponse;
+    } catch {
+      // A 5xx (or gateway) response may carry a non-JSON body; treat it as an
+      // empty error payload so the status still drives classification.
+      return {};
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,6 @@ export {
   AuthKitError,
   LoginRequiredError,
   NoSessionError,
+  RefreshError,
   RefreshTimeoutError,
 } from "./errors";


### PR DESCRIPTION
## Summary
`authkit-js` cleared browser session storage and fired `onRefreshFailure` on **any** non-2xx refresh response, including transient ones (429, 5xx, request timeouts). During a brief WorkOS blip this logs the user out even though their refresh token is still valid. This mirrors the fixes in `authkit-nextjs` (#461) and `authkit-remix` (#88).

The refresh client now classifies failures by HTTP status and only tears down the session for **terminal** errors:

```ts
// http-client.ts — was: throw new RefreshError(error.error_description) for any non-2xx
const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
throw new RefreshError(body.error_description, {
  status,
  error: body.error,           // e.g. "invalid_grant"
  isTransient: RETRYABLE_REFRESH_STATUS_CODES.has(status),
});
```

`RefreshError` gains `status`, `error`, and `isTransient` (exported so callers can branch), and `RefreshTimeoutError` is now `isTransient: true`.

In `create-client.ts`, the destructive path is gated on `!error.isTransient`:

```ts
// #doRefresh: was `if (error instanceof RefreshError)`
if (error instanceof RefreshError && !error.isTransient) {
  removeSessionData(...); // clear storage + org id
  onRefreshFailure?.(...);
  this.#state = { tag: "ERROR" };
} else {
  // transient (429/5xx/timeout/network): keep session, stay AUTHENTICATED so
  // a later getAccessToken() retries
  this.#state = { tag: "AUTHENTICATED" };
}
```

`getAccessToken()` and `switchToOrganization()` likewise rethrow a transient `RefreshError` (so the caller can retry) instead of converting it to `LoginRequiredError` / redirecting to sign-in. Terminal `400 invalid_grant` / `401` behavior is unchanged. A non-JSON 5xx body is now parsed safely so its status still drives classification.

## Test plan
- `npm run build` — passes
- `npm run format:check` — passes
- `npx jest` — 104 passing, including new `http-client` tests (transient 408/429/5xx classification, non-JSON 5xx body, terminal 400/401, raw network failure not wrapped) and `create-client` tests (session preserved + `onRefreshFailure` not fired on 408/429/500/503/504; terminal still clears).

Link to Devin session: https://app.devin.ai/sessions/fc39103abf694f90b1c92dd714a81461
Requested by: @m0tzy