### PR TITLE
ci: protect npm installs with Socket Firewall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,32 @@ on:
       - "main"
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Pre-merge Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+          allow-external-fork-fallback: true
+
       - name: Setup
         run: npm ci
+
+      - name: Remove Socket Firewall credentials before executing source
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
 
       - name: Format
         run: npm run format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Setup
         run: npm ci
 
-      - name: Remove Socket Firewall credentials before executing source
-        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
-
       - name: Format
         run: npm run format:check
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,3 +38,5 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/release.yml
+    secrets:
+      PUBLIC_SOCKET_FIREWALL_TOKEN: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      PUBLIC_SOCKET_FIREWALL_TOKEN:
+        required: true
 
 defaults:
   run:
@@ -17,14 +20,24 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
 
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
+
       - name: Install Dependencies
         run: |
           npm install
+
+      - name: Restore public registry before build and publication
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
 
       - name: Build project
         run: |

--- a/.github/workflows/socket-tier1-analysis.yml
+++ b/.github/workflows/socket-tier1-analysis.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   socket-vulnerability-analysis:
     runs-on: ubuntu-latest
@@ -27,8 +30,16 @@ jobs:
           echo "distinct_id: ${{ github.event.inputs.distinct_id }}"
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Configure Socket Firewall
+        uses: workos/setup-socket-firewall@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
+        with:
+          token: ${{ secrets.PUBLIC_SOCKET_FIREWALL_TOKEN }}
       - name: Install Socket CLI
         run: npm install -g socket
+      - name: Remove Socket Firewall credentials before analysis
+        uses: workos/setup-socket-firewall/teardown@ca93dd8aa351f54f4729fe3377a9be23c631c25d # v1
       - name: Run Tier 1 reachability scan
         env:
           SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_API_KEY }}


### PR DESCRIPTION
`authkit-js` downloads public npm packages in normal continuous integration, its reusable release workflow, and its scheduled Socket analysis workflow. Those downloads currently bypass the WorkOS Socket Firewall, while the release must still publish directly to npm.

This change protects each download with action-only release `ca93dd8aa351f54f4729fe3377a9be23c631c25d`. The selected-repository `PUBLIC_SOCKET_FIREWALL_TOKEN` secret is passed only to the setup action. Public fork pull requests can use the validated public-registry fallback, while same-repository and default-branch jobs remain fail-closed. Fork-reachable permissions are read-only and checkout credentials are no longer persisted.

The reusable release workflow receives only the named firewall secret. It installs through Socket Firewall after `setup-node`, then invokes teardown at the same release SHA before building or publishing. The scheduled Socket CLI install uses the same setup/install/teardown boundary. Existing test, build, trusted-publishing, release-selection, and reachability-analysis behavior is unchanged. The `pull_request_target` title-lint workflow does not execute contributor-controlled code and remains outside the install path.

Verify the workflow structure with:

```bash
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 .github/workflows/*.yml
```

The rollout classifier reports all three npm download jobs as protected with no ordering, release-reference, token, publication, or trust violations. The earlier public pilot provides external-fork and publication-boundary evidence for this shared workflow shape. No real package publication is performed by this change.
